### PR TITLE
Article CRUD 기능 로직 구현 및 뷰 페이지 추가 & Controller Test 작성

### DIFF
--- a/src/main/java/com/example/projectboard/application/articles/ArticleCommandService.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleCommandService.java
@@ -5,7 +5,7 @@ import com.example.projectboard.domain.articles.ArticleInfo;
 
 public interface ArticleCommandService {
 
-    ArticleInfo registerArticle(ArticleCommand.RegisterReq command);
-
+    ArticleInfo.MainInfo registerArticle(ArticleCommand.RegisterReq command);
     void update(Long articleId, ArticleCommand.UpdateReq command);
+    void delete(Long articleId);
 }

--- a/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ArticleQueryService {
 
-    ArticleInfo getArticle(Long articleId);
-    Page<ArticleInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable);
-    List<ArticleInfo> articleList(ArticleCommand.SearchCondition condition);
+    ArticleInfo.MainInfo getArticle(Long articleId);
+    Page<ArticleInfo.MainInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable);
+    List<ArticleInfo.MainInfo> articleList(ArticleCommand.SearchCondition condition);
 }

--- a/src/main/java/com/example/projectboard/application/articles/ArticleQueryServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleQueryServiceImpl.java
@@ -23,30 +23,30 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     private final ArticleRepository articleRepository;
 
     @Override
-    public ArticleInfo getArticle(Long articleId) {
+    public ArticleInfo.MainInfo getArticle(Long articleId) {
         log.info("{}:{}", getClass().getSimpleName(), "getArticle(Long)");
 
         var article = articleRepository.findById(articleId)
-                .orElseThrow(EntityNotFoundException::new);
+                .orElseThrow(() -> {throw new EntityNotFoundException("존재하지 않는 게시글입니다.");});
 
-        return new ArticleInfo(article);
+        return new ArticleInfo.MainInfo(article);
     }
 
     @Override
-    public Page<ArticleInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable) {
+    public Page<ArticleInfo.MainInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable) {
         log.info("{}:{}", getClass().getSimpleName(), "articles(ArticleCommand.SearchCondition, Pageable)");
 
         return articleRepository.findAll(condition.toSearchCondition(), getPageRequest(pageable))
-                .map(ArticleInfo::new);
+                .map(ArticleInfo.MainInfo::new);
     }
 
     @Override
-    public List<ArticleInfo> articleList(ArticleCommand.SearchCondition condition) {
+    public List<ArticleInfo.MainInfo> articleList(ArticleCommand.SearchCondition condition) {
         log.info("{}:{}", getClass().getSimpleName(), "articleList(ArticleCommand.SearchCondition)");
 
         return articleRepository.findAll(condition.toSearchCondition())
                 .stream()
-                .map(ArticleInfo::new)
+                .map(ArticleInfo.MainInfo::new)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/projectboard/common/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/example/projectboard/common/handler/CommonExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.example.projectboard.common.handler;
+
+import com.example.projectboard.common.exception.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Slf4j
+@ControllerAdvice
+public class CommonExceptionHandler {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({EntityNotFoundException.class, javax.persistence.EntityNotFoundException.class})
+    public String entityNotFoundException(Model model,Exception exception) {
+        log.error("handling {}: {}", exception.getClass().getSimpleName(), exception.getMessage());
+
+        model.addAttribute("exception", exception.getMessage());
+
+        return "error/exception";
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public String illegalArgumentException(Model model, Exception exception) {
+        log.error("handling {}: {}", exception.getClass().getSimpleName(), exception.getMessage());
+
+        model.addAttribute("exception", exception.getMessage());
+
+        return "error/exception";
+    }
+}

--- a/src/main/java/com/example/projectboard/config/WebConfig.java
+++ b/src/main/java/com/example/projectboard/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.example.projectboard.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        var registrar = new DateTimeFormatterRegistrar();
+        registrar.setDateFormatter(DateTimeFormatter.ISO_DATE);
+        registrar.setDateTimeFormatter(DateTimeFormatter.ISO_DATE_TIME);
+        registrar.registerFormatters(registry);
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/articlecomments/ArticleCommentRepository.java
+++ b/src/main/java/com/example/projectboard/domain/articlecomments/ArticleCommentRepository.java
@@ -1,6 +1,7 @@
 package com.example.projectboard.domain.articlecomments;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +10,10 @@ import java.util.List;
 public interface ArticleCommentRepository extends
         JpaRepository<ArticleComment, Long>, ArticleCommentRepositoryCustom{
 
-    @Query("select ac from ArticleComment ac where ac.article.id = :articleId")
+    @Query("SELECT ac FROM ArticleComment ac WHERE ac.article.id = :articleId")
     List<ArticleComment> findByArticleId(@Param("articleId") Long articleId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM ArticleComment ac WHERE ac.article.id = :articleId")
+    void deleteByArticleId(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/example/projectboard/domain/articles/Article.java
+++ b/src/main/java/com/example/projectboard/domain/articles/Article.java
@@ -56,7 +56,7 @@ public class Article extends JpaAuditingFields {
 
         if(StringUtils.hasText(title)) this.title = title;
         if(StringUtils.hasText(content)) this.content = content;
-        if(StringUtils.hasText(hashtag)) this.hashtag = hashtag;
+        this.hashtag = hashtag;
     }
 
     // equals & hashcode override

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
@@ -1,30 +1,63 @@
 package com.example.projectboard.domain.articles;
 
+import com.example.projectboard.domain.articlecomments.ArticleCommentInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
-@Getter
-@ToString
-@AllArgsConstructor
-@Builder
 public class ArticleInfo {
-    private Long articleId;
-    private String title;
-    private String content;
-    private String hashtag;
-    private String createdBy;
-    private LocalDateTime createdAt;
+    @Getter
+    @ToString
+    @AllArgsConstructor
+    @Builder
+    public static class MainInfo {
+        private Long articleId;
+        private String title;
+        private String content;
+        private String hashtag;
+        private String createdBy;
+        private LocalDateTime createdAt;
 
-    public ArticleInfo(Article entity) {
-        this.articleId = entity.getId();
-        this.title = entity.getTitle();
-        this.content = entity.getContent();
-        this.hashtag = (entity.getHashtag() != null) ? entity.getHashtag() : null;
-        this.createdBy = entity.getCreatedBy();
-        this.createdAt = entity.getCreatedAt();
+        public MainInfo(Article entity) {
+            this.articleId = entity.getId();
+            this.title = entity.getTitle();
+            this.content = entity.getContent();
+            this.hashtag = (entity.getHashtag() != null) ? entity.getHashtag() : null;
+            this.createdBy = entity.getCreatedBy();
+            this.createdAt = entity.getCreatedAt();
+        }
+
     }
+
+    @Getter
+    @ToString
+    @AllArgsConstructor
+    @Builder
+    public static class ArticleWithCommentsInfo {
+        private Long articleId;
+        private String title;
+        private String content;
+        private String hashtag;
+        private String createdBy;
+        private LocalDateTime createdAt;
+        private List<ArticleCommentInfo.SimpleInfo> articleComments;
+        public ArticleWithCommentsInfo(Article entity,
+                                       List<ArticleCommentInfo.SimpleInfo> articleComments) {
+
+            this.articleId = entity.getId();
+            this.title = entity.getTitle();
+            this.content = entity.getContent();
+            this.hashtag = (entity.getHashtag() != null) ? entity.getHashtag() : null;
+            this.createdBy = entity.getCreatedBy();
+            this.createdAt = entity.getCreatedAt();
+            this.articleComments = new ArrayList<>();
+            this.articleComments.addAll(articleComments);
+        }
+    }
+
 }

--- a/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDtoMapper.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDtoMapper.java
@@ -21,5 +21,5 @@ public interface ArticleDtoMapper {
     ArticleCommand.SearchCondition toCommand(ArticleDto.SearchCondition req);
 
     // INFO -> DTO
-    ArticleDto.MainInfoResponse toDto(ArticleInfo info);
+    ArticleDto.MainInfoResponse toDto(ArticleInfo.MainInfo info);
 }

--- a/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleCommandController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleCommandController.java
@@ -1,0 +1,45 @@
+package com.example.projectboard.interfaces.web.articles;
+
+import com.example.projectboard.application.articles.ArticleCommandService;
+import com.example.projectboard.interfaces.dto.articles.ArticleDto;
+import com.example.projectboard.interfaces.dto.articles.ArticleDtoMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class ArticleCommandController {
+
+    private final ArticleCommandService articleCommandService;
+    private final ArticleDtoMapper articleDtoMapper;
+
+    @PostMapping("/articles")
+    public String registerArticle(ArticleDto.RegisterReq req) {
+        articleCommandService.registerArticle(articleDtoMapper.toCommand(req));
+
+        return "redirect:/articles";
+    }
+
+    @PutMapping("/articles/{id}")
+    public String updateArticle(@PathVariable Long id,
+                                ArticleDto.UpdateReq req) {
+
+        articleCommandService.update(id, articleDtoMapper.toCommand(req));
+
+        return "redirect:/articles/" + id;
+    }
+
+    @DeleteMapping("/articles/{id}")
+    public String deleteArticle(@PathVariable Long id) {
+
+        articleCommandService.delete(id);
+
+        return "redirect:/articles";
+    }
+}

--- a/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
@@ -39,8 +39,7 @@ public class ArticleViewController {
                            @PageableDefault(size = 15, direction = Sort.Direction.DESC, sort = "createdAt") Pageable pageable) {
 
         var searchCondition = articleDtoMapper.toCommand(ArticleDto.SearchCondition.of(searchType, searchValue));
-        var articles = articleQueryService.articles(searchCondition, pageable);
-//                .map(articleDtoMapper::toDto);
+        var articles = articleQueryService.articles(searchCondition, pageable).map(articleDtoMapper::toDto);
 
         var barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         model.addAttribute("articles", articles);

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -23,7 +23,7 @@
     </header>
 
     <div class="row g-5 ms-lg-5 mt-4">
-        <section class="col-1 order-md-last ms-3">
+        <section class="col-2 order-md-last ms-3">
             <aside>
                 <p><span id="nickname" th:text="${article.createdBy}">Uno</span></p>
                 <p><a id="email" href="mailto:djkehh@gmail.com">uno@mail.com</a></p>
@@ -33,15 +33,16 @@
         </section>
 
         <article id="article-content" class="col-md-9 col-lg-8 ms-4">
-            <pre th:text="${article.content}">본문</pre>
+            <pre th:utext="${article.content}">본문</pre>
         </article>
     </div>
 
-    <div class="row g-5 ms-lg-5" id="article-buttons">
-        <form id="delete-article-form">
+    <div class="row g-5 ms-lg-5 mt-2" id="article-buttons">
+        <form id="delete-article-form" th:action="@{/articles/{id}(id=${article.articleId})}" th:method="post">
+            <input type="hidden" name="_method" value="delete"/>
             <div class="pb-5 d-grid gap-2 d-md-block ms-4">
-                <a class="btn btn-success me-md-2" role="button" id="update-article">수정</a>
-                <button class="btn btn-danger me-md-2" type="submit">삭제</button>
+                <a class="btn btn-success btn-sm me-md-2" role="button" id="update-article" th:href="@{/articles/{id}/edit(id=${article.articleId})}">수정</a>
+                <button class="btn btn-danger btn-sm me-md-2" type="submit">삭제</button>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/articles/edit-form.html
+++ b/src/main/resources/templates/articles/edit-form.html
@@ -29,7 +29,7 @@
         <h3>게시글 수정</h3>
     </header>
 
-    <form id="article-edit-form" th:action="@{/articles/{id}/edit(id=${article.articleId})}" th:method="post">
+    <form id="article-edit-form" th:action="@{/articles/{id}(id=${article.articleId})}" th:method="post">
         <input type="hidden" name="_method" value="put"/>
         <div class="row mb-3 justify-content-md-center">
             <label for="title" class="col-sm-2 col-lg-1 col-form-label text-sm-end">제목</label>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -40,8 +40,8 @@
                                 </div>
                                 <div class="col-lg-8 col-md-6 col-sm-12 p-0">
                                     <label for="search-value" hidden>검색어</label>
-                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value"
-                                           name="searchValue" th:value="${param.searchValue}">
+                                    <input type="text" placeholder="검색어... ('작성일'은 'yyyy-MM-dd' 으로 검색)"
+                                           class="form-control" id="search-value" name="searchValue" th:value="${param.searchValue}">
                                 </div>
                                 <div class="col-lg-1 col-md-3 col-sm-12 p-0">
                                     <button type="submit" class="btn btn-base">
@@ -130,7 +130,7 @@
 
     <div class="row">
         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-            <a class="btn btn-primary me-md-2" role="button" id="write-article">글쓰기</a>
+            <a class="btn btn-primary me-md-2" role="button" id="write-article" th:href="@{/articles/new}">글쓰기</a>
         </div>
     </div>
 

--- a/src/main/resources/templates/error/exception.html
+++ b/src/main/resources/templates/error/exception.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <title>게시판 페이지</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+</head>
+
+<body>
+<header th:replace="/fragments/header.html :: header-config">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="container">
+  <section class="py-5 text-center container">
+    <div class="row py-lg-5">
+      <div class="col-lg-6 col-md-8 mx-auto">
+        <p class="lead text-muted" th:text="${exception}">에러 메세지</p>
+        <p>
+          <a type="button" class="btn btn-secondary" id="cancel-button" th:href="@{/articles}">홈으로 돌아가기</a>
+        </p>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer th:replace="/fragments/footer.html :: footer-config">
+  <hr>
+  푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/test/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceTest.java
+++ b/src/test/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceTest.java
@@ -16,14 +16,12 @@ class ArticleCommentCommandServiceTest {
 
     @Autowired
     private EntityManager em;
-
     @Autowired
     private ArticleCommentRepository articleCommentRepository;
-
     @Autowired
-    private ArticleCommentCommandService articleCommentCommandService;
+    private ArticleCommentCommandService sut;
 
-    @DisplayName("[성공] 게시글 댓글 등록 테스트")
+    @DisplayName("[성공][service] 게시글 댓글 등록 테스트")
     @Test
     void givenRegisterReq_WhenRegisterComment_WorksFine() {
         // given
@@ -36,14 +34,14 @@ class ArticleCommentCommandServiceTest {
                 .build();
 
         // when
-        var result = articleCommentCommandService.registerComment(req);
+        var result = sut.registerComment(req);
 
         // then
         assertThat(result.getArticleId()).isEqualTo(articleId);
         assertThat(result.getContent()).isEqualTo(content);
     }
 
-    @DisplayName("[성공] 게시글 댓글 수정 테스트")
+    @DisplayName("[성공][service] 게시글 댓글 수정 테스트")
     @Test
     void givenUpdateReq_WhenUpdate_WorksFine() {
         // given
@@ -55,13 +53,11 @@ class ArticleCommentCommandServiceTest {
                 .build();
 
         // when
-        articleCommentCommandService.update(updateCommentId, req);
-
+        sut.update(updateCommentId, req);
         em.clear();
 
-        var updatedComment = articleCommentRepository.findById(updateCommentId).orElse(null);
-
         // then
+        var updatedComment = articleCommentRepository.findById(updateCommentId).orElse(null);
         assertThat(updatedComment).isNotNull();
         assertThat(updatedComment.getContent()).isEqualTo(updateContent);
     }

--- a/src/test/java/com/example/projectboard/application/articlecomments/ArticleCommentQueryServiceTest.java
+++ b/src/test/java/com/example/projectboard/application/articlecomments/ArticleCommentQueryServiceTest.java
@@ -17,28 +17,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ArticleCommentQueryServiceTest {
 
     @Autowired
-    private ArticleCommentQueryService articleCommentQueryService;
+    private ArticleCommentQueryService sut;
     @Autowired
     private ArticleCommentRepository articleCommentRepository;
 
-    @DisplayName("[성공] 게시글 댓글 단건 조회")
+    @DisplayName("[성공][service] 게시글 댓글 단건 조회")
     @Test
     void givenCommentId_whenGetComment_thenWorksFine() {
         // given
         var commentId = 3L;
 
         // when
-        var result = articleCommentQueryService.getComment(commentId);
-
-        var findComment = articleCommentRepository.findById(commentId).orElse(null);
+        var result = sut.getComment(commentId);
 
         // then
+        var findComment = articleCommentRepository.findById(commentId).orElse(null);
         assertThat(findComment).isNotNull();
         assertThat(result.getContent()).isEqualTo(findComment.getContent());
         assertThat(result.getArticleId()).isEqualTo(findComment.getArticle().getId());
     }
 
-    @DisplayName("[성공] 해당 게시글에 작성된 댓글 리스트 조회 by articleId")
+    @DisplayName("[성공][service] 해당 게시글에 작성된 댓글 리스트 조회 by articleId")
     @Test
     void givenArticleIdAndPageable_whenCommentsByArticleId_thenWorksFine() {
         // given
@@ -47,7 +46,7 @@ class ArticleCommentQueryServiceTest {
         var pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleCommentQueryService.commentsByArticleId(articleId, pageable);
+        var result = sut.commentsByArticleId(articleId, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(articleCommentsTotal);
@@ -55,7 +54,7 @@ class ArticleCommentQueryServiceTest {
         assertThat(result.getSize()).isEqualTo(20);
     }
 
-    @DisplayName("[성공] 댓글 검색 페이징 결과 조회 - only by 작성일")
+    @DisplayName("[성공][service] 댓글 검색 페이징 결과 조회 - only by 작성일")
     @Test
     void givenCreatedAtAndPageable_whenComments_thenWorksFine() {
         // given
@@ -67,14 +66,14 @@ class ArticleCommentQueryServiceTest {
         var pageable = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleCommentQueryService.comments(condition, pageable);
+        var result = sut.comments(condition, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(4);
         assertThat(result.getTotalPages()).isEqualTo(1);
     }
 
-    @DisplayName("[성공] 댓글 검색 페이징 결과 조회 - only by 작성자")
+    @DisplayName("[성공][service] 댓글 검색 페이징 결과 조회 - only by 작성자")
     @Test
     void givenCreatedByAndPageable_whenComments_thenWorksFine() {
         // given
@@ -86,39 +85,38 @@ class ArticleCommentQueryServiceTest {
         var pageable = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleCommentQueryService.comments(condition, pageable);
+        var result = sut.comments(condition, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
     }
 
-    @DisplayName("[성공] 댓글 검색(작성일 & 작성자) 페이징 결과 조회")
+    @DisplayName("[성공][service] 댓글 검색(작성일 & 작성자) 페이징 결과 조회")
     @Test
     void givenSearchCondiAndPageable_whenComments_thenWorksFine() {
         // given
         var condition = ArticleCommentCommand.SearchCondition.builder()
                 .createdAt(LocalDateTime.of(2022, 2, 2, 9, 30))
                 .createdBy("Lonnie")
-
                 .build();
 
         var pageSize = 20;
         var pageable = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleCommentQueryService.comments(condition, pageable);
+        var result = sut.comments(condition, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
 
-    @DisplayName("[성공] 전체 게시글별 댓글 리스트 조회(group by articleId)")
+    @DisplayName("[성공][service] 전체 게시글별 댓글 리스트 조회(group by articleId)")
     @Test
-    void givenTestData_whenCommentsGroupByArticleId_thenWorksFine() {
+    void givenNothing_whenCommentsGroupByArticleId_thenWorksFine() {
         // given
 
         // when
-        var result = articleCommentQueryService.commentsGroupByArticleId();
+        var result = sut.commentsGroupByArticleId();
 
         // then
         assertThat(result.size()).isEqualTo(200);

--- a/src/test/java/com/example/projectboard/application/articles/ArticleQueryServiceTest.java
+++ b/src/test/java/com/example/projectboard/application/articles/ArticleQueryServiceTest.java
@@ -17,19 +17,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ArticleQueryServiceTest {
 
     @Autowired
-    private ArticleQueryService articleQueryService;
+    private ArticleQueryService sut;
 
     @Autowired
     private ArticleRepository articleRepository;
 
-    @DisplayName("[성공] 게시글 단건 조회 테스트")
+    @DisplayName("[성공][service] 게시글 단건 조회 테스트")
     @Test
     void givenArticleId_whenGetArticle_thenWorksFine() {
         // given
         var articleId = 2L;
 
         // when
-        var result = articleQueryService.getArticle(articleId);
+        var result = sut.getArticle(articleId);
 
         var findArticle = articleRepository.findById(articleId).orElse(null);
 
@@ -40,7 +40,7 @@ class ArticleQueryServiceTest {
         assertThat(result.getCreatedBy()).isEqualTo(findArticle.getCreatedBy());
     }
 
-    @DisplayName("[성공] 게시글 검색조건 페이징 조회 테스트 - 일부 조건")
+    @DisplayName("[성공][service] 게시글 검색조건 페이징 조회 테스트 - 일부 조건")
     @Test
     void givenSearchCondiAndPageable_whenArticles_thenWorksFine() {
         // given
@@ -55,13 +55,13 @@ class ArticleQueryServiceTest {
         var pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleQueryService.articles(condition, pageable);
+        var result = sut.articles(condition, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
     }
 
-    @DisplayName("[성공] 게시글 검색조건 페이징 조회 테스트 - 모든 조건 포함")
+    @DisplayName("[성공][service] 게시글 검색조건 페이징 조회 테스트 - 모든 조건 포함")
     @Test
     void givenAllSearchCondiAndPageable_whenArticles_thenWorksFine() {
         // given
@@ -80,21 +80,21 @@ class ArticleQueryServiceTest {
         var pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "id"));
 
         // when
-        var result = articleQueryService.articles(condition, pageable);
+        var result = sut.articles(condition, pageable);
 
         // then
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getTotalPages()).isEqualTo(1);
     }
 
-    @DisplayName("[성공] 전체 댓글 리스트 조회 테스트 - 검색조건 없음")
+    @DisplayName("[성공][service] 전체 댓글 리스트 조회 테스트 - 검색조건 없음")
     @Test
     void givenNoneCondition_whenArticleList_thenSelectAllComments() {
         // given
         var condition = ArticleCommand.SearchCondition.builder().build();
 
         // when
-        var result = articleQueryService.articleList(condition);
+        var result = sut.articleList(condition);
 
         // then
         assertThat(result.size()).isEqualTo(200);

--- a/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
@@ -1,0 +1,150 @@
+package com.example.projectboard.interfaces.web.articles;
+
+import com.example.projectboard.common.exception.EntityNotFoundException;
+import com.example.projectboard.domain.articles.ArticleRepository;
+import com.example.projectboard.interfaces.dto.articles.ArticleDto;
+import com.example.projectboard.util.FormDataEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(FormDataEncoder.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class ArticleCommandControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private FormDataEncoder encoder;
+
+    @DisplayName("[성공][controller][POST] 게시글 등록 테스트")
+    @Test
+    void givenRegisterReq_WhenPostMapping_ThenRedirectToMainPage() throws Exception {
+
+        //given
+        var title = "새로운 글 제목";
+        var content = "새로운 글 내용입니다.";
+        var hashtag = "#newArticle";
+        var requestReq = ArticleDto.RegisterReq.builder()
+                .title(title)
+                .content(content)
+                .hashtag(hashtag)
+                .build();
+
+        var beforeRegister = articleRepository.count();
+
+        //when & then
+        mvc.perform(post("/articles")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(requestReq))
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles"))
+                .andExpect(view().name("redirect:/articles"));
+
+        assertThat(articleRepository.count()).isEqualTo(beforeRegister + 1);
+    }
+
+    @DisplayName("[성공][controller][PUT] 게시글 수정 테스트")
+    @Test
+    void givenArticleIdAndUpdateReq_WhenPutMapping_ThenRedirectToDetailPage() throws Exception {
+
+        //given
+        var articleId = 1L;
+        var updateTitle = "수정한 제목입니다.";
+        var updateContent = "수정한 내용입니다.";
+        var updateHashtag = "#update";
+
+        var updateReq = ArticleDto.UpdateReq.builder()
+                .title(updateTitle)
+                .content(updateContent)
+                .hashtag(updateHashtag)
+                .build();
+
+        //when & then
+        mvc.perform(put("/articles/" + articleId)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(updateReq))
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId))
+                .andExpect(view().name("redirect:/articles/" + articleId));
+
+        var updatedArticle = articleRepository.findById(articleId).orElse(null);
+
+        assertThat(updatedArticle).isNotNull();
+        assertThat(updatedArticle.getTitle()).isEqualTo(updateTitle);
+        assertThat(updatedArticle.getContent()).isEqualTo(updateContent);
+        assertThat(updatedArticle.getHashtag()).isEqualTo(updateHashtag);
+    }
+
+    @DisplayName("[실패][controller][PUT] 게시글 수정 테스트 - 존재하지 않는 게시글")
+    @Test
+    void givenNonExistArticleIdAndUpdateReq_WhenPutMapping_ThenShowErrorPage() throws Exception {
+
+        //given
+        var articleId = 400L;
+        var updateTitle = "수정한 제목입니다.";
+        var updateContent = "수정한 내용입니다.";
+        var updateHashtag = "#update";
+
+        var updateReq = ArticleDto.UpdateReq.builder()
+                .title(updateTitle)
+                .content(updateContent)
+                .hashtag(updateHashtag)
+                .build();
+
+        //when & then
+        var mvcResult = mvc.perform(put("/articles/" + articleId)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(encoder.encode(updateReq))
+        ).andExpect(status().is4xxClientError()).andReturn();
+
+        assertThat(mvcResult.getResolvedException()).isNotNull();
+        assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @DisplayName("[성공][controller][DELETE] 게시글 삭제 테스트")
+    @Test
+    void givenArticleId_WhenDeleteMapping_ThenRedirectToMainPage() throws Exception {
+
+        //given
+        var articleId = 5L;
+        var beforeDeleteTotal = articleRepository.count();
+
+        //when & then
+        mvc.perform(delete("/articles/" + articleId))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles"))
+                .andExpect(view().name("redirect:/articles"));
+
+        assertThat(beforeDeleteTotal).isEqualTo(articleRepository.count() + 1);
+    }
+
+    @DisplayName("[실패][controller][PUT] 게시글 삭제 테스트 - 존재하지 않는 게시글")
+    @Test
+    void givenNonExistArticleId_WhenDeleteMapping_ThenShowErrorPage() throws Exception {
+
+        //given
+        var articleId = 400L;
+
+        //when & then
+        var mvcResult = mvc.perform(delete("/articles/" + articleId))
+                .andExpect(status().is4xxClientError()).andReturn();
+
+        assertThat(mvcResult.getResolvedException()).isNotNull();
+        assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/example/projectboard/util/FormDataEncoder.java
+++ b/src/test/java/com/example/projectboard/util/FormDataEncoder.java
@@ -1,0 +1,32 @@
+package com.example.projectboard.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@TestComponent
+public class FormDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public FormDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public String encode(Object obj) {
+        Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
+        MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
+        valueMap.setAll(fieldMap);
+
+        return UriComponentsBuilder.newInstance()
+                .queryParams(valueMap)
+                .encode()
+                .build()
+                .getQuery();
+    }
+}


### PR DESCRIPTION
1. view 페이지 수정 및 추가 
* index, detail, edit-form 의 글쓰기/글수정 버튼 a href 링크 수정 
* detail 삭제 버튼 a href 링크 수정 
* 간단한 에러 페이지 추가 

2. Article create/update/delete 구현 및 Service 계층 추가 수정 
* Article : 글 등록/ 글 수정/ 글 삭제 비즈니스 로직 구현함.
* Article update 메서드의 해시태그 수정 로직 변경.
* ArticleCommandService에 ArticleCommentRepository 의존성 주입 -> ArticleComment와 Article 간의 ManyToOne 단방향 매핑으로 인한 참조의 무결성 때문에 삭제시 ArticleComment를 먼저 삭제해야함.
* ArticleComment 삭제시 댓글 수 만큼 삭제 쿼리의 성능 개선을 위해 Bulk Delete 쿼리 직접 입력.
* ArticleInfo 클래스를 ArticleInfo.MainInfo & ArticleInfo.ArticleWithCommentsInfo로 수정. 
* 모든 ArticleService 클래스의 ArticleInfo 리턴타입을 -> ArticleInfo.MainInfo 로 수정 & Mapper toDto 메서드 수정 
* 모든 ArticleService의 orElseThrow의 EntityNotFoundException에 커스텀 메세지 작성함.

3. Controller 작성 및 Controller Test 작성
* 변경을 일으키는(명령) 전용 Controller(POST/PUT/DELETE) 작성 : ArticleCommandController
* @SpringBootTest & MockMvc로 ArticleCommandController Test 작성 및 정상 동작 확인함.
* create/update 요청에 필요한 FormData 객체를 QueryString으로 변환해서 반환하는 FormDataEncoder를 @TestComponent로 작성하고 Import해 Test에 사용함.
* Controller Test 실패 경우의 정상 동작을 확인하기 위해 @ControllerAdvice를 선언한 ExceptionHandler 작성함. 기본 로직 : 에러 발생시 Model에 에러 메세지를 전달해 error/exception 페이지 반환함.

This closes #7