### PR TITLE
ArticleComment CRUD 기능 로직 구현 및 Test 작성 & 약간의 코드 수정 업데이트

### DIFF
--- a/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandService.java
+++ b/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandService.java
@@ -7,4 +7,6 @@ public interface ArticleCommentCommandService {
     ArticleCommentInfo.MainInfo registerComment(ArticleCommentCommand.RegisterReq command);
 
     void update(Long commentId, ArticleCommentCommand.UpdateReq command);
+
+    void delete(Long commentId);
 }

--- a/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceImpl.java
@@ -21,7 +21,7 @@ public class ArticleCommentCommandServiceImpl implements ArticleCommentCommandSe
     @Override
     @Transactional
     public ArticleCommentInfo.MainInfo registerComment(ArticleCommentCommand.RegisterReq command) {
-        log.info("{}:{}", getClass().getSimpleName(), "registerComment");
+        log.info("{}:{}", getClass().getSimpleName(), "registerComment(ArticleCommentCommand.RegisterReq)");
 
         // 게시글 엔티티 조회
         var article = articleRepository.findById(command.getArticleId())
@@ -35,13 +35,26 @@ public class ArticleCommentCommandServiceImpl implements ArticleCommentCommandSe
     @Override
     @Transactional
     public void update(Long commentId, ArticleCommentCommand.UpdateReq command) {
-        log.info("{}:{}", getClass().getSimpleName(), "updateComment");
+        log.info("{}:{}", getClass().getSimpleName(), "update(Long, ArticleCommentCommand.UpdateReq)");
 
         // 업데이트할 엔티티 조회
         var comment = articleCommentRepository.findById(commentId)
-                .orElseThrow(EntityNotFoundException::new);
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 댓글입니다."));
 
         // 댓글 수정
         comment.update(command.getContent());
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long commentId) {
+        log.info("{}:{}", getClass().getSimpleName(), "delete(Long)");
+
+        // 엔티티 조회
+        var comment = articleCommentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 댓글입니다."));
+
+        // 댓글 삭제
+        articleCommentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/example/projectboard/application/articles/ArticleCommandServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleCommandServiceImpl.java
@@ -33,7 +33,7 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
 
         // update 할 엔티티 조회
         var article = articleRepository.findById(articleId)
-                .orElseThrow(() -> {throw new EntityNotFoundException("존재하지 않는 게시글입니다.");});
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
         article.update(command.getTitle(), command.getContent(), command.getHashtag());
     }
@@ -48,7 +48,7 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
 
         // 게시글 엔티티 조회
         var article = articleRepository.findById(articleId)
-                .orElseThrow(() -> {throw new EntityNotFoundException("존재하지 않는 게시글입니다.");});
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
         // 게시글 삭제
         articleRepository.delete(article);

--- a/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
@@ -10,6 +10,9 @@ import java.util.List;
 public interface ArticleQueryService {
 
     ArticleInfo.MainInfo getArticle(Long articleId);
+
+    ArticleInfo.ArticleWithCommentsInfo getArticleWithComments(Long articleId);
     Page<ArticleInfo.MainInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable);
     List<ArticleInfo.MainInfo> articleList(ArticleCommand.SearchCondition condition);
+    long articleCount();
 }

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
@@ -45,9 +45,9 @@ public class ArticleInfo {
         private String hashtag;
         private String createdBy;
         private LocalDateTime createdAt;
-        private List<ArticleCommentInfo.SimpleInfo> articleComments;
+        private List<ArticleCommentInfo.SimpleInfo> comments;
         public ArticleWithCommentsInfo(Article entity,
-                                       List<ArticleCommentInfo.SimpleInfo> articleComments) {
+                                       List<ArticleCommentInfo.SimpleInfo> comments) {
 
             this.articleId = entity.getId();
             this.title = entity.getTitle();
@@ -55,8 +55,10 @@ public class ArticleInfo {
             this.hashtag = (entity.getHashtag() != null) ? entity.getHashtag() : null;
             this.createdBy = entity.getCreatedBy();
             this.createdAt = entity.getCreatedAt();
-            this.articleComments = new ArrayList<>();
-            this.articleComments.addAll(articleComments);
+            this.comments = new ArrayList<>();
+            if (comments != null && comments.size() > 0) {
+                this.comments.addAll(comments);
+            }
         }
     }
 

--- a/src/main/java/com/example/projectboard/interfaces/dto/articlecomments/ArticleCommentDtoMapper.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articlecomments/ArticleCommentDtoMapper.java
@@ -6,7 +6,6 @@ import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper(

--- a/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
@@ -9,6 +9,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 public class ArticleDto {
@@ -84,6 +85,29 @@ public class ArticleDto {
         private String title;
         private String content;
         private String hashtag;
+        private String createdBy;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @ToString
+    @Builder
+    public static class ArticleWithCommentsResponse {
+        private Long articleId;
+        private String title;
+        private String content;
+        private String hashtag;
+        private String createdBy;
+        private LocalDateTime createdAt;
+        private List<CommentInfoResponse> comments;
+    }
+
+    @Getter
+    @ToString
+    @Builder
+    public static class CommentInfoResponse {
+        private Long commentId;
+        private String content;
         private String createdBy;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDtoMapper.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDtoMapper.java
@@ -1,5 +1,6 @@
 package com.example.projectboard.interfaces.dto.articles;
 
+import com.example.projectboard.domain.articlecomments.ArticleCommentInfo;
 import com.example.projectboard.domain.articles.ArticleCommand;
 import com.example.projectboard.domain.articles.ArticleInfo;
 import org.mapstruct.InjectionStrategy;
@@ -22,4 +23,6 @@ public interface ArticleDtoMapper {
 
     // INFO -> DTO
     ArticleDto.MainInfoResponse toDto(ArticleInfo.MainInfo info);
+    ArticleDto.CommentInfoResponse toDto(ArticleCommentInfo.SimpleInfo info);
+    ArticleDto.ArticleWithCommentsResponse toDto(ArticleInfo.ArticleWithCommentsInfo info);
 }

--- a/src/main/java/com/example/projectboard/interfaces/web/articlecomments/CommentCommandController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articlecomments/CommentCommandController.java
@@ -1,0 +1,43 @@
+package com.example.projectboard.interfaces.web.articlecomments;
+
+import com.example.projectboard.application.articlecomments.ArticleCommentCommandService;
+import com.example.projectboard.interfaces.dto.articlecomments.ArticleCommentDto;
+import com.example.projectboard.interfaces.dto.articlecomments.ArticleCommentDtoMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class CommentCommandController {
+
+    private final ArticleCommentCommandService commentCommandService;
+    private final ArticleCommentDtoMapper commentDtoMapper;
+
+    @PostMapping("/article-comments")
+    public String registerComment(ArticleCommentDto.RegisterReq req) {
+        commentCommandService.registerComment(commentDtoMapper.toCommand(req));
+
+        return "redirect:/articles/" + req.getArticleId();
+    }
+
+    @PutMapping("/article-comments/{id}")
+    public String update(@PathVariable Long id,
+                         ArticleCommentDto.UpdateReq req, Long articleId) {
+        commentCommandService.update(id, commentDtoMapper.toCommand(req));
+
+        return "redirect:/articles/" + articleId;
+    }
+
+    @DeleteMapping("/article-comments/{id}")
+    public String delete(@PathVariable Long id, Long articleId) {
+        commentCommandService.delete(id);
+
+        return "redirect:/articles/" + articleId;
+    }
+}

--- a/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
@@ -52,7 +52,7 @@ public class ArticleViewController {
     @GetMapping("/{id}")
     public String articleDetail(@PathVariable Long id, Model model) {
 
-        var article = articleDtoMapper.toDto(articleQueryService.getArticle(id));
+        var article = articleDtoMapper.toDto(articleQueryService.getArticleWithComments(id));
         model.addAttribute("article", article);
         return "articles/detail";
     }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -6,7 +6,8 @@
     <meta name="description" content="">
     <title>게시글 페이지</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="/css/articles/article-content.css" rel="stylesheet">
 </head>
 
@@ -27,7 +28,11 @@
             <aside>
                 <p><span id="nickname" th:text="${article.createdBy}">Uno</span></p>
                 <p><a id="email" href="mailto:djkehh@gmail.com">uno@mail.com</a></p>
-                <p><time id="created-at" th:datetime="${article.createdAt}" th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2022-01-01</time></p>
+                <p>
+                    <time id="created-at" th:datetime="${article.createdAt}"
+                          th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2022-01-01
+                    </time>
+                </p>
                 <p><span id="hashtag" th:text="${article.hashtag}">#java</span></p>
             </aside>
         </section>
@@ -41,7 +46,8 @@
         <form id="delete-article-form" th:action="@{/articles/{id}(id=${article.articleId})}" th:method="post">
             <input type="hidden" name="_method" value="delete"/>
             <div class="pb-5 d-grid gap-2 d-md-block ms-4">
-                <a class="btn btn-success btn-sm me-md-2" role="button" id="update-article" th:href="@{/articles/{id}/edit(id=${article.articleId})}">수정</a>
+                <a class="btn btn-success btn-sm me-md-2" role="button" id="update-article"
+                   th:href="@{/articles/{id}/edit(id=${article.articleId})}">수정</a>
                 <button class="btn btn-danger btn-sm me-md-2" type="submit">삭제</button>
             </div>
         </form>
@@ -49,73 +55,68 @@
 
     <div class="row g-5 ms-lg-5">
         <section class="ms-4">
-            <form class="row g-3" id="comment-form">
-                <input type="hidden" class="article-id">
+            <form class="row g-3" id="comment-form" th:action="@{/article-comments}" th:method="post">
+                <input type="hidden" class="article-id" name="articleId" th:value="${article.articleId}">
                 <div class="col-md-9 col-lg-8">
                     <label for="comment-textbox" hidden>댓글</label>
-                    <textarea class="form-control" id="comment-textbox" placeholder="댓글 쓰기.." rows="3" required></textarea>
+                    <textarea class="form-control" id="comment-textbox" name="content" placeholder="댓글 쓰기.." rows="3"
+                              required></textarea>
                 </div>
                 <div class="col-md-3 col-lg-4">
                     <label for="comment-submit" hidden>댓글 쓰기</label>
-                    <button class="btn btn-primary" id="comment-submit" type="submit">쓰기</button>
+                    <button class="btn btn-sm btn-primary" id="comment-submit" type="submit">쓰기</button>
                 </div>
             </form>
 
-            <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3">
+            <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3" th:each="comment : ${article.comments}">
                 <li>
-                    <form class="comment-form">
-                        <input type="hidden" class="article-id">
+                    <form class="comment-form" th:action="@{/article-comments/{id}(id=${comment.commentId})}"
+                          th:method="post">
+                        <input type="hidden" name="_method" value="delete"/>
+                        <input type="hidden" class="article-id" name="articleId" th:value="${article.articleId}">
                         <div class="row">
                             <div class="col-md-10 col-lg-9">
-                                <strong>Uno</strong>
-                                <small><time>2022-01-01</time></small>
-                                <p>
-                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                                    Lorem ipsum dolor sit amet
+                                <strong th:text="${comment.createdBy}">작성자</strong>
+                                <small>
+                                    <time th:datetime="${comment.createdAt}"
+                                          th:text="*{#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm:ss')}">
+                                        2022-01-01
+                                    </time>
+                                </small>
+                                <p th:text="${comment.content}">
+                                    댓글 내용
                                 </p>
                             </div>
                             <div class="col-2 mb-3 align-self-center">
-                                <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
+                                <button type="submit" class="badge text-bg-secondary" id="delete-comment-button">삭제
+                                </button>
                             </div>
                         </div>
                     </form>
-                </li>
-                <li>
-                    <div class="row">
-                        <div class="col-md-10 col-lg-9">
-                            <strong>Uno2</strong>
-                            <small><time>2022-01-01</time></small>
-                            <p>
-                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                                Lorem ipsum dolor sit amet
-                            </p>
-                        </div>
-                        <div class="col-2 mb-3">
-                            <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
-                        </div>
-                    </div>
                 </li>
             </ul>
 
         </section>
     </div>
 
-    <div class="row g-5 ms-lg-5 mt-4">
-        <nav id="pagination" aria-label="Page navigation">
-            <ul class="pagination ms-4">
-                <li class="page-item">
-                    <a class="page-link" href="#" aria-label="Previous">
-                        <span aria-hidden="true">&laquo; prev</span>
-                    </a>
-                </li>
-                <li class="page-item">
-                    <a class="page-link" href="#" aria-label="Next">
-                        <span aria-hidden="true">next &raquo;</span>
-                    </a>
-                </li>
-            </ul>
-        </nav>
-    </div>
+    <!--    <div class="row g-5 ms-lg-5 mt-4">-->
+    <!--        <nav id="pagination" aria-label="Page navigation">-->
+    <!--            <ul class="pagination ms-4">-->
+    <!--                <li class="page-item" th:with="prevId=${article.articleId} - 1, prevAddr=@{/articles/{id}(id=${article.articleId}-1)}">-->
+    <!--                    <a th:class="'page-link' + (${prevId} <= 0 ? ' disabled' : '')"-->
+    <!--                       th:href="(${prevId} <= 0) ? '#' : ${prevAddr}" aria-label="Previous">-->
+    <!--                        <span aria-hidden="true">&laquo; prev</span>-->
+    <!--                    </a>-->
+    <!--                </li>-->
+    <!--                <li class="page-item" th:with="nextId=${article.articleId} + 1, nextAddr=@{/articles/{id}(id=${article.articleId}+1)}">-->
+    <!--                    <a th:class="'page-link' + (${nextId} > ${totalCount} ? ' disabled' : '')"-->
+    <!--                       th:href="(${nextId} > ${totalCount}) ? '#' : ${nextAddr}" aria-label="Next">-->
+    <!--                        <span aria-hidden="true">next &raquo;</span>-->
+    <!--                    </a>-->
+    <!--                </li>-->
+    <!--            </ul>-->
+    <!--        </nav>-->
+    <!--    </div>-->
 </main>
 
 <footer th:replace="/fragments/footer.html :: footer-config">
@@ -123,6 +124,8 @@
     푸터 삽입부
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
+        crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/test/java/com/example/projectboard/interfaces/web/articlecomments/CommentCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/articlecomments/CommentCommandControllerTest.java
@@ -1,0 +1,152 @@
+package com.example.projectboard.interfaces.web.articlecomments;
+
+import com.example.projectboard.common.exception.EntityNotFoundException;
+import com.example.projectboard.domain.articlecomments.ArticleCommentRepository;
+import com.example.projectboard.interfaces.dto.articlecomments.ArticleCommentDto;
+import com.example.projectboard.util.FormDataEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@Import(FormDataEncoder.class)
+@AutoConfigureMockMvc
+class CommentCommandControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ArticleCommentRepository commentRepository;
+
+    @Autowired
+    private FormDataEncoder encoder;
+
+    @DisplayName("[성공][controller][POST] 댓글 등록 테스트")
+    @Test
+    void givenRegisterReq_WhenPostMapping_ThenRedirectToDetailPage() throws Exception {
+
+        //given
+        var articleId = 1L;
+        var content = "새로운 댓글 내용입니다.";
+        var registerReq = ArticleCommentDto.RegisterReq.builder()
+                .articleId(articleId)
+                .content(content)
+                .build();
+
+        var beforeRegister = commentRepository.count();
+
+        //when & then
+        mvc.perform(post("/article-comments")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(registerReq))
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId))
+                .andExpect(view().name("redirect:/articles/" + articleId));
+
+        assertThat(commentRepository.count()).isEqualTo(beforeRegister + 1);
+    }
+
+    @DisplayName("[성공][controller][PUT] 댓글 수정 테스트")
+    @Test
+    void givenCommentIdAndUpdateReq_WhenPutMapping_ThenRedirectToDetailPage() throws Exception {
+
+        //given
+        var commentId = 1L;
+        var articleId = 2L;
+        var updateContent = "수정한 내용입니다.";
+
+        var updateReq = ArticleCommentDto.UpdateReq.builder()
+                .content(updateContent)
+                .build();
+
+        //when & then
+        mvc.perform(put("/article-comments/" + commentId)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .queryParam("content", updateContent)
+                        .queryParam("articleId", String.valueOf(articleId))
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId))
+                .andExpect(view().name("redirect:/articles/" + articleId));
+
+        var updatedComment = commentRepository.findById(commentId).orElse(null);
+
+        assertThat(updatedComment).isNotNull();
+        assertThat(updatedComment.getContent()).isEqualTo(updateContent);
+    }
+
+    @DisplayName("[실패][controller][PUT] 댓글 수정 테스트 - 존재하지 않는 댓글")
+    @Test
+    void givenNonExistCommentIdAndUpdateReq_WhenPutMapping_ThenShowErrorPage() throws Exception {
+
+        //given
+        var commentId = 1500L;
+        var articleId = 2L;
+        var updateContent = "수정한 댓글 내용입니다.";
+
+        var updateReq = ArticleCommentDto.UpdateReq.builder()
+                .content(updateContent)
+                .build();
+
+        //when & then
+        var mvcResult = mvc.perform(put("/article-comments/" + commentId)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(encoder.encode(updateReq))
+                .content(encoder.encode(Map.of("articleId", articleId)))
+        ).andExpect(status().is4xxClientError()).andReturn();
+
+        assertThat(mvcResult.getResolvedException()).isNotNull();
+        assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @DisplayName("[성공][controller][DELETE] 댓글 삭제 테스트")
+    @Test
+    void givenCommentId_WhenDeleteMapping_ThenRedirectToDetailPage() throws Exception {
+
+        //given
+        var commentId = 5L;
+        var articleId = 6L;
+        var beforeDeleteTotal = commentRepository.count();
+
+        //when & then
+        mvc.perform(delete("/article-comments/" + commentId)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(Map.of("articleId", articleId)))
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId))
+                .andExpect(view().name("redirect:/articles/" + articleId));
+
+        assertThat(beforeDeleteTotal).isEqualTo(commentRepository.count() + 1);
+    }
+
+    @DisplayName("[실패][controller][DELETE] 게시글 삭제 테스트 - 존재하지 않는 댓글")
+    @Test
+    void givenNonExistCommentId_WhenDeleteMapping_ThenShowErrorPage() throws Exception {
+
+        //given
+        var commentId = 1500L;
+        var articleId = 1L;
+
+        //when & then
+        var mvcResult = mvc.perform(delete("/article-comments/" + commentId)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(Map.of("articleId", articleId)))
+                )
+                .andExpect(status().is4xxClientError()).andReturn();
+
+        assertThat(mvcResult.getResolvedException()).isNotNull();
+        assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
@@ -39,7 +39,7 @@ class ArticleCommandControllerTest {
         var title = "새로운 글 제목";
         var content = "새로운 글 내용입니다.";
         var hashtag = "#newArticle";
-        var requestReq = ArticleDto.RegisterReq.builder()
+        var registerReq = ArticleDto.RegisterReq.builder()
                 .title(title)
                 .content(content)
                 .hashtag(hashtag)
@@ -50,7 +50,7 @@ class ArticleCommandControllerTest {
         //when & then
         mvc.perform(post("/articles")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .content(encoder.encode(requestReq))
+                        .content(encoder.encode(registerReq))
                 ).andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/articles"))
                 .andExpect(view().name("redirect:/articles"));


### PR DESCRIPTION
1. Article 상세 조회 로직 변경- 댓글 리스트 함께 조회
* Article에 속한 댓글 리스트 반환 Info 클래스 생성.
* Article 상세 조회 시 해당 게시글의 댓글 리스트를 포함시키기 위해 ArticleQueryService에 ArticleCommentRepository 의존성 주입함. 
* ArticleQueryService에 getArticleWithComments(Long) 구현.
* 이에 따른 ArticleDto & Mapper & Controller 수정.

2. ArticleComment CRUD 기능 로직 구현 & View에 댓글 동작 기능 추가 
* 댓글 등록/ 수정/ 삭제 기능 로직 구현.
* detail.html에 댓글 리스트 뿌리기/등록/삭제 기능 추가 업데이트.

3. ArticleCommentCommandController Test 작성 

4. 번외 : 불필요한 패키지 import 삭제 및 변수명 수정 등 변경 업데이트