### PR TITLE
사용자 계정(UserAccount) 도메인 & 로직 추가 

### DIFF
--- a/src/main/java/com/example/projectboard/application/users/UserAccountCommandService.java
+++ b/src/main/java/com/example/projectboard/application/users/UserAccountCommandService.java
@@ -1,0 +1,13 @@
+package com.example.projectboard.application.users;
+
+import com.example.projectboard.domain.users.UserAccountCommand;
+import com.example.projectboard.domain.users.UserAccountInfo;
+
+public interface UserAccountCommandService {
+
+    UserAccountInfo registerUser(UserAccountCommand.RegisterReq command);
+
+    void updateUserInfo(Long userAccountId, UserAccountCommand.UpdateReq command);
+
+    void delete(Long userAccountId);
+}

--- a/src/main/java/com/example/projectboard/application/users/UserAccountCommandServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/users/UserAccountCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package com.example.projectboard.application.users;
+
+import com.example.projectboard.common.exception.EntityNotFoundException;
+import com.example.projectboard.domain.users.UserAccountCommand;
+import com.example.projectboard.domain.users.UserAccountInfo;
+import com.example.projectboard.domain.users.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserAccountCommandServiceImpl implements UserAccountCommandService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Override
+    @Transactional
+    public UserAccountInfo registerUser(UserAccountCommand.RegisterReq command) {
+        log.info("{}: {}", getClass().getSimpleName(), "registerUser(UserAccountCommand.RegisterReq)");
+
+        var userAccount = command.toEntity();
+
+        return UserAccountInfo.of(userAccountRepository.save(userAccount));
+    }
+
+    @Override
+    @Transactional
+    public void updateUserInfo(Long userAccountId, UserAccountCommand.UpdateReq command) {
+        log.info("{}: {}", getClass().getSimpleName(), "updateUserInfo(Long, UserAccountCommand.UpdateReq)");
+
+        // 수정할 엔티티 조회
+        var userAccount = userAccountRepository.findById(userAccountId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+
+        // 유저 정보 업데이트
+        userAccount.updateUserInfo(command.getEmail(), command.getPhoneNumber());
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long userAccountId) {
+        log.info("{}: {}", getClass().getSimpleName(), "delete(Long)");
+
+        // 삭제할 엔티티 조회
+        var userAccount = userAccountRepository.findById(userAccountId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+
+        // 엔티티 삭제
+        userAccountRepository.delete(userAccount);
+    }
+}

--- a/src/main/java/com/example/projectboard/common/exception/UsernameNotFoundException.java
+++ b/src/main/java/com/example/projectboard/common/exception/UsernameNotFoundException.java
@@ -1,0 +1,20 @@
+package com.example.projectboard.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UsernameNotFoundException extends RuntimeException {
+    public UsernameNotFoundException() {
+        super("유저를 찾을 수 없습니다.");
+        log.error("유저를 찾을 수 없습니다. UsernameNotFoundException");
+    }
+
+    public UsernameNotFoundException(String message) {
+        super(message);
+        log.error("{}: {}", message, getClass().getSimpleName());
+    }
+
+    public UsernameNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/articles/Article.java
+++ b/src/main/java/com/example/projectboard/domain/articles/Article.java
@@ -1,6 +1,7 @@
 package com.example.projectboard.domain.articles;
 
 import com.example.projectboard.domain.JpaAuditingFields;
+import com.example.projectboard.domain.users.UserAccount;
 import lombok.*;
 import org.springframework.util.StringUtils;
 
@@ -31,22 +32,30 @@ public class Article extends JpaAuditingFields {
 
     private String hashtag; // 해시태그
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserAccount userAccount;
+
     @Builder(builderClassName = "ArticleWithoutHashtag", builderMethodName = "ArticleWithoutHashtag")
     public Article(String title,
-                   String content) {
+                   String content,
+                   UserAccount userAccount) {
 
         this.title = title;
         this.content = content;
+        this.userAccount = userAccount;
     }
 
     @Builder(builderClassName = "ArticleWithHashtag", builderMethodName = "ArticleWithHashtag")
     public Article(String title,
                    String content,
-                   String hashtag) {
+                   String hashtag,
+                   UserAccount userAccount) {
 
         this.title = title;
         this.content = content;
         this.hashtag = hashtag;
+        this.userAccount = userAccount;
     }
 
     // 수정 메서드

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleCommand.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleCommand.java
@@ -1,5 +1,6 @@
 package com.example.projectboard.domain.articles;
 
+import com.example.projectboard.domain.users.UserAccount;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -16,11 +17,12 @@ public class ArticleCommand {
         private String content;
         private String hashtag;
 
-        public Article toEntity() {
+        public Article toEntity(UserAccount userAccount) {
             return Article.ArticleWithHashtag()
                     .title(title)
                     .content(content)
                     .hashtag(hashtag)
+                    .userAccount(userAccount)
                     .build();
         }
     }

--- a/src/main/java/com/example/projectboard/domain/users/UserAccount.java
+++ b/src/main/java/com/example/projectboard/domain/users/UserAccount.java
@@ -1,0 +1,102 @@
+package com.example.projectboard.domain.users;
+
+import com.example.projectboard.domain.JpaAuditingFields;
+import lombok.*;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserAccount extends JpaAuditingFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false, updatable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @Column(length = 100, unique = true, nullable = false)
+    private String email;
+
+    @Column(length = 50, nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private RoleType role;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum RoleType {
+        USER("ROLE_USER"),
+        ADMIN("ROLE_ADMIN");
+
+        private final String roleValue;
+    }
+
+    private UserAccount(String username,
+                       String password,
+                       String name,
+                       String email,
+                       String phoneNumber,
+                       RoleType role) {
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+    }
+
+    // 기본 일반 사용자 생성 메서드
+    public static UserAccount of(String username,
+                                 String password,
+                                 String name,
+                                 String email,
+                                 String phoneNumber) {
+        return new UserAccount(username, password, name, email, phoneNumber, RoleType.USER);
+    }
+
+    // 사용자 지정 ROLE_TYPE 의 사용자 생성 메서드 -> role == null 인 경우 : ROLE_USER 로 설정
+    public static UserAccount of(String username,
+                                 String password,
+                                 String name,
+                                 String email,
+                                 String phoneNumber,
+                                 RoleType role) {
+        if(role == null) role = RoleType.USER;
+        return new UserAccount(username, password, name, email, phoneNumber, role);
+    }
+
+    public void updatePassword(String encodedPwd) {
+        this.password = encodedPwd;
+    }
+
+    public void updateUserInfo(String email, String phoneNumber) {
+        if(StringUtils.hasText(email)) this.email = email;
+        if(StringUtils.hasText(phoneNumber)) this.phoneNumber = phoneNumber;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        UserAccount userAccount = (UserAccount) obj;
+        return id != null && id.equals(userAccount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/users/UserAccountCommand.java
+++ b/src/main/java/com/example/projectboard/domain/users/UserAccountCommand.java
@@ -1,0 +1,32 @@
+package com.example.projectboard.domain.users;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class UserAccountCommand {
+
+    @ToString
+    @Getter
+    @Builder
+    public static class RegisterReq {
+        private String username;
+        private String password;
+        private String name;
+        private String email;
+        private String phoneNumber;
+        private UserAccount.RoleType role;
+
+        public UserAccount toEntity() {
+            return UserAccount.of(username, password, name, email, phoneNumber, role);
+        }
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class UpdateReq {
+        private String email;
+        private String phoneNumber;
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/users/UserAccountInfo.java
+++ b/src/main/java/com/example/projectboard/domain/users/UserAccountInfo.java
@@ -1,0 +1,35 @@
+package com.example.projectboard.domain.users;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+@Builder
+public class UserAccountInfo {
+
+    private Long userId;
+    private String username;
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private String role;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static UserAccountInfo of(UserAccount entity) {
+        return UserAccountInfo.builder()
+                .userId(entity.getId())
+                .username(entity.getUsername())
+                .name(entity.getName())
+                .email(entity.getEmail())
+                .phoneNumber(entity.getPhoneNumber())
+                .role(entity.getRole().getRoleValue())
+                .createdAt(entity.getCreatedAt())
+                .modifiedAt(entity.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/users/UserAccountRepository.java
+++ b/src/main/java/com/example/projectboard/domain/users/UserAccountRepository.java
@@ -1,0 +1,10 @@
+package com.example.projectboard.domain.users;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+
+    Optional<UserAccount> findByUsername(String username);
+}

--- a/src/main/java/com/example/projectboard/interfaces/dto/users/UserAccountDto.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/users/UserAccountDto.java
@@ -1,0 +1,45 @@
+package com.example.projectboard.interfaces.dto.users;
+
+import com.example.projectboard.domain.users.UserAccount;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+public class UserAccountDto {
+
+    @ToString
+    @Getter
+    @Builder
+    public static class RegisterReq {
+        private String username;
+        private String password;
+        private String name;
+        private String email;
+        private String phoneNumber;
+        private UserAccount.RoleType role;
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class UpdateReq {
+        private String email;
+        private String phoneNumber;
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class MainInfoResponse {
+        private Long userId;
+        private String username;
+        private String name;
+        private String email;
+        private String phoneNumber;
+        private String role;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+    }
+}

--- a/src/main/java/com/example/projectboard/interfaces/dto/users/UserAccountDtoMapper.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/users/UserAccountDtoMapper.java
@@ -1,0 +1,25 @@
+package com.example.projectboard.interfaces.dto.users;
+
+import com.example.projectboard.domain.users.UserAccountCommand;
+import com.example.projectboard.domain.users.UserAccountInfo;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface UserAccountDtoMapper {
+
+    // DTO -> COMMAND
+
+    UserAccountCommand.RegisterReq toCommand(UserAccountDto.RegisterReq req);
+
+    UserAccountCommand.UpdateReq toCommand(UserAccountDto.UpdateReq req);
+
+    // INFO -> DTO
+
+    UserAccountDto.MainInfoResponse toDto(UserAccountInfo info);
+}

--- a/src/main/java/com/example/projectboard/interfaces/web/AuthViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/AuthViewController.java
@@ -1,0 +1,20 @@
+package com.example.projectboard.interfaces.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Slf4j
+@Controller
+public class AuthViewController {
+
+    @GetMapping("/auth/sign-up")
+    public String signUpPage() {
+        return "sign-up";
+    }
+
+    @GetMapping("/auth/login")
+    public String signInPage() {
+        return "sign-in";
+    }
+}

--- a/src/main/java/com/example/projectboard/interfaces/web/MainViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/MainViewController.java
@@ -1,0 +1,13 @@
+package com.example.projectboard.interfaces.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainViewController {
+
+    @GetMapping("/")
+    public String root() {
+        return "forward:/articles";
+    }
+}

--- a/src/main/java/com/example/projectboard/interfaces/web/users/UserAccountCommandController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/users/UserAccountCommandController.java
@@ -1,0 +1,26 @@
+package com.example.projectboard.interfaces.web.users;
+
+import com.example.projectboard.application.users.UserAccountCommandService;
+import com.example.projectboard.interfaces.dto.users.UserAccountDto;
+import com.example.projectboard.interfaces.dto.users.UserAccountDtoMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class UserAccountCommandController {
+
+    private final UserAccountCommandService userAccountCommandService;
+    private final UserAccountDtoMapper userAccountDtoMapper;
+
+    @PostMapping("/user-accounts")
+    public String registerUser(UserAccountDto.RegisterReq req) {
+        log.info("userAccountDto.RegisterReq={}", req);
+        userAccountCommandService.registerUser(userAccountDtoMapper.toCommand(req));
+
+        return "redirect:/";
+    }
+}

--- a/src/main/resources/static/css/sign-in.css
+++ b/src/main/resources/static/css/sign-in.css
@@ -1,0 +1,84 @@
+.bd-placeholder-img {
+    font-size: 1.125rem;
+    text-anchor: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+}
+
+@media (min-width: 768px) {
+    .bd-placeholder-img-lg {
+        font-size: 3.5rem;
+    }
+}
+
+.b-example-divider {
+    height: 3rem;
+    background-color: rgba(0, 0, 0, .1);
+    border: solid rgba(0, 0, 0, .15);
+    border-width: 1px 0;
+    box-shadow: inset 0 .5em 1.5em rgba(0, 0, 0, .1), inset 0 .125em .5em rgba(0, 0, 0, .15);
+}
+
+.b-example-vr {
+    flex-shrink: 0;
+    width: 1.5rem;
+    height: 100vh;
+}
+
+.bi {
+    vertical-align: -.125em;
+    fill: currentColor;
+}
+
+.nav-scroller {
+    position: relative;
+    z-index: 2;
+    height: 2.75rem;
+    overflow-y: hidden;
+}
+
+.nav-scroller .nav {
+    display: flex;
+    flex-wrap: nowrap;
+    padding-bottom: 1rem;
+    margin-top: -1px;
+    overflow-x: auto;
+    text-align: center;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+}
+
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    align-items: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    background-color: #f5f5f5;
+}
+
+.form-signin {
+    max-width: 330px;
+    padding: 15px;
+}
+
+.form-signin .form-floating:focus-within {
+    z-index: 2;
+}
+
+.form-signin input[type="text"] {
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.form-signin input[type="password"] {
+    margin-bottom: 10px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}

--- a/src/main/resources/templates/sign-in.html
+++ b/src/main/resources/templates/sign-in.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <title>로그인 페이지</title>
+
+    <link rel="canonical" href="https://getbootstrap.com/docs/5.2/examples/sign-in/">
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+
+    <meta name="theme-color" content="#712cf9">
+
+    <!-- Custom styles for this template -->
+    <link href="/css/sign-in.css" th:href="@{/css/sign-in.css}" rel="stylesheet">
+
+</head>
+<body class="text-center">
+
+<main class="form-signin w-100 m-auto">
+
+    <img class="mb-4" src="https://getbootstrap.com/docs/5.2/assets/brand/bootstrap-logo.svg" alt="" width="72"
+    height="57">
+    <h1 class="h3 mb-3 fw-normal">Please Sign in</h1>
+    <div th:if="${param.error}" class="alert alert-error">
+        Invalid username and password.
+    </div>
+    <form th:action="@{/auth/login-proc}" th:method="post">
+        <div class="form-floating">
+            <input type="text" class="form-control" id="username" name="username" placeholder="Login ID">
+            <label for="username">Login ID</label>
+        </div>
+        <div class="form-floating">
+            <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+            <label for="password">Password</label>
+        </div>
+
+        <button class="w-100 btn btn-lg btn-primary" type="submit">Login</button>
+        <a class="w-100 btn btn-lg btn-secondary mt-2" type="button" th:href="@{/}">Cancel</a>
+        <div class="mt-3">
+            <a th:href="@{/auth/sign-up}">아직 회원이 아니신가요? 회원가입 하러 가기</a>
+        </div>
+        <p class="mt-5 mb-3 text-muted">&copy; 2017–2022</p>
+    </form>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/sign-up.html
+++ b/src/main/resources/templates/sign-up.html
@@ -46,9 +46,9 @@
             </div>
         </div>
         <div class="row mb-3 justify-content-md-center">
-            <label for="phone" class="col-sm-2 col-lg-1 col-form-label text-sm-end">휴대전화 번호</label>
+            <label for="phoneNumber" class="col-sm-3 col-lg-1 col-form-label text-sm-end fs-6">휴대전화 번호</label>
             <div class="col-sm-8 col-lg-6">
-                <input type="tel" class="form-control" pattern="[0-9]{3}-[0-9]{3,4}-[0-9]{4}" id="phone" name="phone" required>
+                <input type="tel" class="form-control" pattern="[0-9]{3}-[0-9]{3,4}-[0-9]{4}" id="phoneNumber" name="phoneNumber" required>
             </div>
         </div>
         <div class="row mb-5 justify-content-md-center">


### PR DESCRIPTION
1. 사용자(UserAccount) 도메인 추가 
* UserAccount 엔티티 추가.
* UserAccountCommand/Info 데이터 클래스 추가.
* UserAccountRepository 추가.
* Article-UserAccount 엔티티간 @ManyToOne 단방향 매핑 설정.
* 매핑 설정에 따른 ArticleCommand의 toEntity() -> UserAccount를 파라미터로 받아 설정하도록 수정함.

2. UserAccount Service 구현 
* UserAccount 의 CUD 기능로직 구현 -> UserAccountCommandService
* Username을 통한 엔티티 조회시 발생하는 UsernameNotFoundException 커스텀 예외 등록함.

3. UserAccountController & Dto 구현 
* UserAccountController : 사용자 등록 (POST) 
* UserAccountDto & UserAccountDtoMapper 구현함.

4. 회원등록/회원 로그인 뷰 페이지
* sign-in/sign-up html & css 페이지 작성함.
* 로그인 페이지 example: https://getbootstrap.com/docs/5.2/examples/sign-in/
* 인증(가입/로그인)관련 Controller 생성 및 GetMapping 메서드 구현함.
* 추가 수정 : "/" 루트 Path가 바로 기본 게시판 페이지로 넘어갈 수 있도록 MainViewController 추가함.

This closes #9