### PR TITLE
Controller Test를 @SpringBootTest --> @WebMvcTest로 변환 작업

### DIFF
--- a/src/main/java/com/example/projectboard/interfaces/dto/articlecomments/ArticleCommentDto.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articlecomments/ArticleCommentDto.java
@@ -24,7 +24,6 @@ public class ArticleCommentDto {
 
         @NotBlank @Size(min = 5, max = 500)
         private String commentBody;
-
     }
 
     @Getter
@@ -56,7 +55,6 @@ public class ArticleCommentDto {
 
         @NotBlank @Size(min = 5, max = 500)
         private String updateCommentBody;
-
     }
 
     @Getter
@@ -80,6 +78,7 @@ public class ArticleCommentDto {
         }
 
     }
+
     @ToString
     @Getter
     @Builder
@@ -92,6 +91,7 @@ public class ArticleCommentDto {
         private LocalDateTime createdAt;
 
     }
+
     @ToString
     @Getter
     @Builder
@@ -101,14 +101,13 @@ public class ArticleCommentDto {
         private String commentBody;
         private String createdBy;
         private LocalDateTime createdAt;
-
     }
+
     @ToString
     @Getter
     @Builder
     public static class GroupByArticleInfoResponse {
         private Long articleId;
         private List<MainInfoResponse> comments;
-
     }
 }

--- a/src/main/java/com/example/projectboard/security/PrincipalUserDetailsService.java
+++ b/src/main/java/com/example/projectboard/security/PrincipalUserDetailsService.java
@@ -6,11 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service
 public class PrincipalUserDetailsService implements UserDetailsService {
 
     private final UserAccountRepository userAccountRepository;

--- a/src/main/java/com/example/projectboard/security/SecurityConfig.java
+++ b/src/main/java/com/example/projectboard/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.projectboard.security;
 
+import com.example.projectboard.domain.users.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +11,7 @@ import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -36,6 +38,11 @@ public class SecurityConfig {
     @Bean
     public AccessDeniedHandler accessDeniedHandler() {
         return new WebAccessDeniedHandler();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return new PrincipalUserDetailsService(userAccountRepository);
     }
 
     @Bean

--- a/src/test/java/com/example/projectboard/config/TestSecurityConfig.java
+++ b/src/test/java/com/example/projectboard/config/TestSecurityConfig.java
@@ -1,0 +1,50 @@
+package com.example.projectboard.config;
+
+import com.example.projectboard.domain.users.UserAccount;
+import com.example.projectboard.domain.users.UserAccountRepository;
+import com.example.projectboard.security.SecurityConfig;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean
+    private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod
+    public void securitySetUp() {
+        given(userAccountRepository.findByUsername(eq("userTest"))).willReturn(Optional.of(UserAccount.of(
+                "userTest",
+                "userTest@pw",
+                "테스트유저",
+                "userTest@gmail.com",
+                "010-1111-1000",
+                UserAccount.RoleType.USER
+        )));
+
+        given(userAccountRepository.findByUsername(eq("userTest2"))).willReturn(Optional.of(UserAccount.of(
+                "userTest2",
+                "userTest2@pw",
+                "테스트유저2",
+                "userTest2@gmail.com",
+                "010-2222-2000",
+                UserAccount.RoleType.USER
+        )));
+
+        given(userAccountRepository.findByUsername(eq("adminTest"))).willReturn(Optional.of(UserAccount.of(
+                "adminTest",
+                "adminTest@pw",
+                "테스트관리자",
+                "adminTest@gmail.com",
+                "010-3333-3000",
+                UserAccount.RoleType.ADMIN
+        )));
+    }
+}

--- a/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleCommandControllerTest.java
@@ -1,15 +1,23 @@
 package com.example.projectboard.interfaces.web.articles;
 
+import com.example.projectboard.application.articles.ArticleCommandService;
 import com.example.projectboard.common.exception.EntityNotFoundException;
 import com.example.projectboard.common.exception.NoAuthorityToUpdateDeleteException;
-import com.example.projectboard.domain.articles.ArticleRepository;
+import com.example.projectboard.config.TestSecurityConfig;
+import com.example.projectboard.domain.articles.ArticleCommand;
+import com.example.projectboard.domain.articles.ArticleInfo;
 import com.example.projectboard.interfaces.dto.articles.ArticleDto;
+import com.example.projectboard.interfaces.dto.articles.ArticleDtoMapper;
+import com.example.projectboard.interfaces.dto.articles.ArticleDtoMapperImpl;
 import com.example.projectboard.util.FormDataEncoder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.TestExecutionEvent;
@@ -17,25 +25,30 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(FormDataEncoder.class)
-@SpringBootTest
+@Import({FormDataEncoder.class, TestSecurityConfig.class})
+@ComponentScan(basePackageClasses = {ArticleDtoMapper.class, ArticleDtoMapperImpl.class})
 @AutoConfigureMockMvc
+@WebMvcTest(controllers = ArticleCommandController.class)
 class ArticleCommandControllerTest {
 
     @Autowired
     private MockMvc mvc;
 
     @Autowired
-    private ArticleRepository articleRepository;
-
-    @Autowired
     private FormDataEncoder encoder;
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @SpyBean
+    private ArticleDtoMapper articleDtoMapper;
+
+    @MockBean
+    private ArticleCommandService articleCommandService;
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[성공][controller][POST] 게시글 등록 테스트 - 인증된 사용자")
     @Test
     void givenRegisterReq_WhenPostMapping_ThenRedirectToMainPage() throws Exception {
@@ -43,14 +56,15 @@ class ArticleCommandControllerTest {
         //given
         var title = "새로운 글 제목";
         var content = "새로운 글 내용입니다.";
-        var hashtag = "#newArticle";
+        var hashtag = "#newArticle, #pink";
         var registerForm = ArticleDto.RegisterForm.builder()
                 .title(title)
                 .content(content)
                 .hashtagContent(hashtag)
                 .build();
 
-        var beforeRegister = articleRepository.count();
+        given(articleCommandService.registerArticle(anyString(), any(ArticleCommand.RegisterReq.class)))
+                .willReturn(any(ArticleInfo.MainInfo.class));
 
         //when & then
         mvc.perform(post("/articles/new")
@@ -61,10 +75,10 @@ class ArticleCommandControllerTest {
                 .andExpect(redirectedUrl("/articles"))
                 .andExpect(view().name("redirect:/articles"));
 
-        assertThat(articleRepository.count()).isEqualTo(beforeRegister + 1);
+        then(articleCommandService).should().registerArticle(anyString(), any(ArticleCommand.RegisterReq.class));
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[성공][controller][PUT] 게시글 수정 테스트 - 인증된 사용자(작성자)")
     @Test
     void givenArticleIdAndUpdateReq_WhenPutMapping_ThenRedirectToDetailPage() throws Exception {
@@ -73,33 +87,48 @@ class ArticleCommandControllerTest {
         var articleId = 2L;
         var updateTitle = "수정한 제목입니다.";
         var updateContent = "수정한 내용입니다.";
-        var updateHashtag = "#update";
+        var updateHashtag = "#update, #hashtag";
 
-        var updateReq = ArticleDto.UpdateForm.builder()
-                .articleId(articleId)
-                .title(updateTitle)
-                .content(updateContent)
-//                .hashtag(updateHashtag)
-                .build();
+        var updateForm = getUpdateForm(articleId, updateTitle, updateContent, updateHashtag);
+
+        willDoNothing().given(articleCommandService)
+                .update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
 
         //when & then
         mvc.perform(put("/articles/" + articleId + "/edit")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .content(encoder.encode(updateReq))
+                        .content(encoder.encode(updateForm))
                         .with(csrf())
                 ).andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/articles/" + articleId))
                 .andExpect(view().name("redirect:/articles/" + articleId));
 
-        var updatedArticle = articleRepository.findById(articleId).orElse(null);
-
-        assertThat(updatedArticle).isNotNull();
-        assertThat(updatedArticle.getTitle()).isEqualTo(updateTitle);
-        assertThat(updatedArticle.getContent()).isEqualTo(updateContent);
-//        assertThat(updatedArticle.getHashtag()).isEqualTo(updateHashtag);
+        then(articleCommandService).should().update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[실패][controller][PUT] 게시글 수정 테스트 - 인증되지 않은 사용자")
+    @Test
+    void givenNotAuthenticatedUserWithUpdateReq_WhenPutMapping_ThenRedirectToLoginPage() throws Exception {
+        // given
+        var articleId = 2L;
+        var updateTitle = "수정한 제목입니다.";
+        var updateContent = "수정한 내용입니다.";
+        var updateHashtag = "#update, #hashtag";
+
+        var updateForm = getUpdateForm(articleId, updateTitle, updateContent, updateHashtag);
+
+        // when & then
+        mvc.perform(put("/articles/" + articleId + "/edit")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(updateForm))
+                        .with(csrf())
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        then(articleCommandService).shouldHaveNoInteractions();
+    }
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][PUT] 게시글 수정 테스트 - 수정 권한이 없는 인증된 사용자")
     @Test
     void givenNoAuthorityToUpdateUsername_WhenPutMapping_ThenShowErrorPage() throws Exception {
@@ -110,12 +139,10 @@ class ArticleCommandControllerTest {
         var updateContent = "수정한 내용입니다.";
         var updateHashtag = "#update";
 
-        var updateForm = ArticleDto.UpdateForm.builder()
-                .articleId(articleId)
-                .title(updateTitle)
-                .content(updateContent)
-//                .hashtag(updateHashtag)
-                .build();
+        var updateForm = getUpdateForm(articleId, updateTitle, updateContent, updateHashtag);
+
+        willThrow(NoAuthorityToUpdateDeleteException.class).given(articleCommandService)
+                .update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
 
         //when & then
         var mvcResult = mvc.perform(put("/articles/" + articleId + "/edit")
@@ -126,9 +153,10 @@ class ArticleCommandControllerTest {
 
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(NoAuthorityToUpdateDeleteException.class);
+        then(articleCommandService).should().update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][PUT] 게시글 수정 테스트 - 존재하지 않는 게시글")
     @Test
     void givenNonExistArticleIdAndUpdateReq_WhenPutMapping_ThenShowErrorPage() throws Exception {
@@ -139,12 +167,10 @@ class ArticleCommandControllerTest {
         var updateContent = "수정한 내용입니다.";
         var updateHashtag = "#update";
 
-        var updateReq = ArticleDto.UpdateForm.builder()
-                .articleId(articleId)
-                .title(updateTitle)
-                .content(updateContent)
-//                .hashtag(updateHashtag)
-                .build();
+        var updateReq = getUpdateForm(articleId, updateTitle, updateContent, updateHashtag);
+
+        willThrow(EntityNotFoundException.class).given(articleCommandService)
+                .update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
 
         //when & then
         var mvcResult = mvc.perform(put("/articles/" + articleId + "/edit")
@@ -155,16 +181,19 @@ class ArticleCommandControllerTest {
 
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+
+        then(articleCommandService).should().update(eq(articleId), anyString(), any(ArticleCommand.UpdateReq.class));
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[성공][controller][DELETE] 게시글 삭제 테스트")
     @Test
     void givenArticleId_WhenDeleteMapping_ThenRedirectToMainPage() throws Exception {
 
         //given
         var articleId = 4L;
-        var beforeDeleteTotal = articleRepository.count();
+
+        willDoNothing().given(articleCommandService).delete(anyLong(), anyString());
 
         //when & then
         mvc.perform(delete("/articles/" + articleId).with(csrf()))
@@ -172,10 +201,24 @@ class ArticleCommandControllerTest {
                 .andExpect(redirectedUrl("/articles"))
                 .andExpect(view().name("redirect:/articles"));
 
-        assertThat(beforeDeleteTotal).isEqualTo(articleRepository.count() + 1);
+        then(articleCommandService).should().delete(anyLong(), anyString());
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[실패][controller][DELETE] 게시글 삭제 테스트 - 인증되지 않은 사용자")
+    @Test
+    void givenNotAuthenticatedUser_WhenDeleteMapping_ThenRedirectToMainPage() throws Exception {
+        //given
+        var articleId = 4L;
+
+        //when & then
+        mvc.perform(delete("/articles/" + articleId).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        then(articleCommandService).shouldHaveNoInteractions();
+    }
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][PUT] 게시글 삭제 테스트 - 존재하지 않는 게시글")
     @Test
     void givenNonExistArticleId_WhenDeleteMapping_ThenShowErrorPage() throws Exception {
@@ -183,15 +226,20 @@ class ArticleCommandControllerTest {
         //given
         var articleId = 400L;
 
+        willThrow(EntityNotFoundException.class).given(articleCommandService)
+                .delete(anyLong(), anyString());
+
         //when & then
         var mvcResult = mvc.perform(delete("/articles/" + articleId).with(csrf()))
                 .andExpect(status().is4xxClientError()).andReturn();
 
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(EntityNotFoundException.class);
+
+        then(articleCommandService).should().delete(anyLong(), anyString());
     }
 
-    @WithUserDetails(value = "jo0oy", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][PUT] 게시글 삭제 테스트 - 삭제 권한이 없는 인증된 사용자")
     @Test
     void givenNoAuthorityToUpdateUsername_WhenDeleteMapping_ThenShowErrorPage() throws Exception {
@@ -199,11 +247,25 @@ class ArticleCommandControllerTest {
         //given
         var articleId = 1L;
 
+        willThrow(NoAuthorityToUpdateDeleteException.class).given(articleCommandService)
+                .delete(anyLong(), anyString());
+
         //when & then
         var mvcResult = mvc.perform(delete("/articles/" + articleId).with(csrf()))
                 .andExpect(status().isForbidden()).andReturn();
 
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(NoAuthorityToUpdateDeleteException.class);
+
+        then(articleCommandService).should().delete(anyLong(), anyString());
+    }
+
+    private static ArticleDto.UpdateForm getUpdateForm(long articleId, String updateTitle, String updateContent, String updateHashtag) {
+        return ArticleDto.UpdateForm.builder()
+                .articleId(articleId)
+                .title(updateTitle)
+                .content(updateContent)
+                .hashtagContent(updateHashtag)
+                .build();
     }
 }

--- a/src/test/java/com/example/projectboard/interfaces/web/users/UserAccountCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/users/UserAccountCommandControllerTest.java
@@ -2,17 +2,22 @@ package com.example.projectboard.interfaces.web.users;
 
 import com.example.projectboard.application.users.UserAccountCommandService;
 import com.example.projectboard.common.exception.NoAuthorityToUpdateDeleteException;
+import com.example.projectboard.config.TestSecurityConfig;
 import com.example.projectboard.domain.users.UserAccount;
-import com.example.projectboard.domain.users.UserAccountRepository;
+import com.example.projectboard.domain.users.UserAccountCommand;
+import com.example.projectboard.domain.users.UserAccountInfo;
 import com.example.projectboard.interfaces.dto.users.UserAccountDto;
 import com.example.projectboard.interfaces.dto.users.UserAccountDtoMapper;
+import com.example.projectboard.interfaces.dto.users.UserAccountDtoMapperImpl;
 import com.example.projectboard.util.FormDataEncoder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.TestExecutionEvent;
@@ -20,28 +25,33 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(FormDataEncoder.class)
-@SpringBootTest
+@Import({FormDataEncoder.class, TestSecurityConfig.class})
+@ComponentScan(basePackageClasses = {UserAccountDtoMapper.class, UserAccountDtoMapperImpl.class})
 @AutoConfigureMockMvc
-class UserAccountCommandControllerTest {
+@WebMvcTest(controllers = UserAccountCommandController.class)
+public class UserAccountCommandControllerTest {
 
     @Autowired
     private MockMvc mvc;
 
     @Autowired
-    private UserAccountRepository userAccountRepository;
-
-    @Autowired
     private FormDataEncoder encoder;
+
+    @SpyBean
+    private UserAccountDtoMapper userAccountDtoMapper;
+
+    @MockBean
+    private UserAccountCommandService userAccountCommandService;
 
     @DisplayName("[성공][controller][POST] 유저 등록 테스트")
     @Test
-    void givenRegisterReq_WhenPostMapping_ThenRedirectToMainPage() throws Exception {
-
+    void givenRegisterReq_WhenPostMapping_ThenRedirectToSignUpSuccessPage() throws Exception {
         //given
         var username = "newUser";
         var password = "newUser1234!";
@@ -49,45 +59,44 @@ class UserAccountCommandControllerTest {
         var email = "newUser@naver.com";
         var phoneNumber = "010-9090-0909";
         var role = UserAccount.RoleType.USER;
-        var registerForm = UserAccountDto.RegisterForm.builder()
-                .username(username)
-                .password(password)
-                .name(name)
-                .email(email)
-                .phoneNumber(phoneNumber)
-                .role(role)
-                .build();
+        var registerForm = getRegisterForm(username, password, name, email, phoneNumber, role);
 
-        var beforeRegister = userAccountRepository.count();
+        given(userAccountCommandService.verifyDuplicateUsername(username)).willReturn(true);
+        given(userAccountCommandService.verifyDuplicateEmail(email)).willReturn(true);
+        given(userAccountCommandService.registerUser(any(UserAccountCommand.RegisterReq.class)))
+                .willReturn(any(UserAccountInfo.class));
 
-        //when & then
+        //when
         mvc.perform(post("/accounts/sign-up")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .content(encoder.encode(registerForm))
                         .with(csrf())
                 ).andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("/**/sign-up/success"));
+                .andExpect(redirectedUrlPattern("/**/sign-up/success"))
+                .andDo(print());
 
-        assertThat(userAccountRepository.count()).isEqualTo(beforeRegister + 1);
+        then(userAccountCommandService).should().verifyDuplicateUsername(eq(username));
+        then(userAccountCommandService).should().verifyDuplicateEmail(eq(email));
+        then(userAccountCommandService).should().registerUser(any(UserAccountCommand.RegisterReq.class));
     }
 
     @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[성공][controller][PUT] 유저 정보 수정 테스트 - 인증된 사용자(본인)")
     @Test
-    void givenUserIdAndUpdateReq_WhenPutMapping_ThenRedirectToMePage() throws Exception {
+    void givenUpdateReq_WhenPutMapping_ThenRedirectToMePage() throws Exception {
 
         //given
         var userId = 1L;
+        var username = "userTest";
         var email = "userTest@gmail.com";
-        var updateEmail = "userTest@naver.com";
+        var updateEmail = "userTest@email.com";
         var updatePhoneNumber = "010-0101-1010";
 
-        var updateReq = UserAccountDto.UpdateForm.builder()
-                .userId(userId)
-                .beforeEmail(email)
-                .email(updateEmail)
-                .phoneNumber(updatePhoneNumber)
-                .build();
+        var updateReq = getUpdateForm(userId, email, updateEmail, updatePhoneNumber);
+
+        given(userAccountCommandService.verifyDuplicateEmail(updateEmail)).willReturn(true);
+        willDoNothing().given(userAccountCommandService)
+                .updateUserInfo(eq(userId), eq(username), any(UserAccountCommand.UpdateReq.class));
 
         //when & then
         mvc.perform(put("/accounts/" + userId + "/edit")
@@ -97,30 +106,54 @@ class UserAccountCommandControllerTest {
                 ).andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("/**/me"));
 
-        var updatedUser = userAccountRepository.findById(userId).orElse(null);
+        then(userAccountCommandService).should().verifyDuplicateEmail(eq(updateEmail));
+        then(userAccountCommandService).should()
+                .updateUserInfo(anyLong(), anyString(), any(UserAccountCommand.UpdateReq.class));
+    }
 
-        assertThat(updatedUser).isNotNull();
-        assertThat(updatedUser.getEmail()).isEqualTo(updateEmail);
-        assertThat(updatedUser.getPhoneNumber()).isEqualTo(updatePhoneNumber);
+    @DisplayName("[실패][controller][PUT] 유저 정보 수정 테스트 - 인증되지 않은 사용자")
+    @Test
+    void givenUpdateReqAndNotAuthenticated_WhenPutMapping_ThenRedirectToLoginPage() throws Exception {
+
+        //given
+        var userId = 1L;
+        var email = "userTest@gmail.com";
+        var updateEmail = "userTest@email.com";
+        var updatePhoneNumber = "010-0101-1010";
+
+        var updateReq = getUpdateForm(userId, email, updateEmail, updatePhoneNumber);
+
+        given(userAccountCommandService.verifyDuplicateEmail(updateEmail)).willReturn(true);
+        willDoNothing().given(userAccountCommandService)
+                .updateUserInfo(eq(userId), anyString(), any(UserAccountCommand.UpdateReq.class));
+
+        //when & then
+        mvc.perform(put("/accounts/" + userId + "/edit")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(encoder.encode(updateReq))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        then(userAccountCommandService).shouldHaveNoInteractions();
     }
 
     @WithUserDetails(value = "userTest2", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][PUT] 유저 정보 수정 테스트 - 수정 권한이 없는 인증된 사용자")
     @Test
-    void givenUserIdAndUpdateReqWithForbiddenUsername_WhenPutMapping_ThenThrowsException() throws Exception {
+    void givenUpdateReqWithForbiddenUsername_WhenPutMapping_ThenThrowsException() throws Exception {
 
         //given
         var userId = 1L;
         var email = "userTest@gmail.com";
-        var updateEmail = "userTest111@naver.com";
+        var updateEmail = "userTest@email.com";
         var updatePhoneNumber = "010-0101-1010";
 
-        var updateReq = UserAccountDto.UpdateForm.builder()
-                .userId(userId)
-                .beforeEmail(email)
-                .email(updateEmail)
-                .phoneNumber(updatePhoneNumber)
-                .build();
+        var updateReq = getUpdateForm(userId, email, updateEmail, updatePhoneNumber);
+
+        given(userAccountCommandService.verifyDuplicateEmail(updateEmail)).willReturn(true);
+        willThrow(NoAuthorityToUpdateDeleteException.class)
+                .given(userAccountCommandService).updateUserInfo(eq(userId), anyString(), any(UserAccountCommand.UpdateReq.class));
 
         //when & then
         var mvcResult = mvc.perform(put("/accounts/" + userId + "/edit")
@@ -129,6 +162,9 @@ class UserAccountCommandControllerTest {
                         .with(csrf()))
                 .andExpect(status().is4xxClientError()).andReturn();
 
+        then(userAccountCommandService).should().verifyDuplicateEmail(eq(updateEmail));
+        then(userAccountCommandService).should()
+                .updateUserInfo(anyLong(), anyString(), any(UserAccountCommand.UpdateReq.class));
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(NoAuthorityToUpdateDeleteException.class);
     }
@@ -136,11 +172,12 @@ class UserAccountCommandControllerTest {
     @WithUserDetails(value = "adminTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[성공][controller][DELETE] 유저 삭제 테스트 - 인증된 관리자 계정")
     @Test
-    void givenUserId_WhenDeleteMapping_ThenRedirectToMainPage() throws Exception {
+    void givenUserIdWithAdminUser_WhenDeleteMapping_ThenRedirectToMainPage() throws Exception {
 
         //given
         var userId = 3L;
-        var beforeDelete = userAccountRepository.count();
+
+        willDoNothing().given(userAccountCommandService).delete(eq(userId), anyString());
 
         //when & then
         mvc.perform(delete("/accounts/" + userId)
@@ -148,10 +185,10 @@ class UserAccountCommandControllerTest {
                 ).andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
 
-        assertThat(userAccountRepository.count()).isEqualTo(beforeDelete - 1);
+        then(userAccountCommandService).should().delete(eq(userId), anyString());
     }
 
-    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest2", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][controller][DELETE] 유저 삭제 테스트 - 삭제 권한이 없는 인증된 사용자")
     @Test
     void givenUserIdWithForbiddenUsername_WhenDeleteMapping_ThenThrowsException() throws Exception {
@@ -159,11 +196,43 @@ class UserAccountCommandControllerTest {
         //given
         var userId = 2L;
 
+        willThrow(NoAuthorityToUpdateDeleteException.class).willDoNothing()
+                .given(userAccountCommandService).delete(eq(userId), anyString());
+
         //when & then
         var mvcResult = mvc.perform(delete("/accounts/" + userId).with(csrf()))
                 .andExpect(status().is4xxClientError()).andReturn();
 
+        then(userAccountCommandService).should().delete(eq(userId), anyString());
         assertThat(mvcResult.getResolvedException()).isNotNull();
         assertThat(mvcResult.getResolvedException()).isInstanceOf(NoAuthorityToUpdateDeleteException.class);
+    }
+
+    private static UserAccountDto.RegisterForm getRegisterForm(String username,
+                                                               String password,
+                                                               String name,
+                                                               String email,
+                                                               String phoneNumber,
+                                                               UserAccount.RoleType role) {
+        return UserAccountDto.RegisterForm.builder()
+                .username(username)
+                .password(password)
+                .name(name)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .role(role)
+                .build();
+    }
+
+    private static UserAccountDto.UpdateForm getUpdateForm(Long userId,
+                                                           String email,
+                                                           String updateEmail,
+                                                           String updatePhoneNumber) {
+        return UserAccountDto.UpdateForm.builder()
+                .userId(userId)
+                .beforeEmail(email)
+                .email(updateEmail)
+                .phoneNumber(updatePhoneNumber)
+                .build();
     }
 }

--- a/src/test/java/com/example/projectboard/interfaces/web/users/UserAccountViewControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/users/UserAccountViewControllerTest.java
@@ -1,25 +1,46 @@
 package com.example.projectboard.interfaces.web.users;
 
+import com.example.projectboard.application.users.UserAccountQueryService;
+import com.example.projectboard.common.exception.NoAuthorityToUpdateDeleteException;
+import com.example.projectboard.config.TestSecurityConfig;
+import com.example.projectboard.domain.users.UserAccount;
+import com.example.projectboard.domain.users.UserAccountInfo;
+import com.example.projectboard.interfaces.dto.users.UserAccountDtoMapper;
+import com.example.projectboard.interfaces.dto.users.UserAccountDtoMapperImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
+@Import(TestSecurityConfig.class)
+@ComponentScan(basePackageClasses = {UserAccountDtoMapper.class, UserAccountDtoMapperImpl.class})
 @AutoConfigureMockMvc
-class UserAccountViewControllerTest {
+@WebMvcTest(controllers = UserAccountViewController.class)
+public class UserAccountViewControllerTest {
 
     @Autowired
     private MockMvc mvc;
+
+    @SpyBean
+    private UserAccountDtoMapper userAccountDtoMapper;
+
+    @MockBean
+    private UserAccountQueryService userAccountQueryService;
 
     @DisplayName("[성공][view][GET] 회원가입 페이지")
     @Test
@@ -30,8 +51,7 @@ class UserAccountViewControllerTest {
         mvc.perform(get("/accounts/sign-up"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("users/sign-up"))
-                .andDo(print());
+                .andExpect(view().name("users/sign-up"));
     }
 
     @DisplayName("[성공][view][GET] 회원가입 성공 페이지")
@@ -42,9 +62,7 @@ class UserAccountViewControllerTest {
         mvc.perform(get("/accounts/sign-up/success"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("users/sign-up-success"))
-                .andDo(print());
-
+                .andExpect(view().name("users/sign-up-success"));
     }
 
     @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -52,24 +70,29 @@ class UserAccountViewControllerTest {
     @Test
     void givenNothingWithRoleUserAccount_whenRequestingMeView_thenReturnsMeView() throws Exception {
         // Given
+        var username = "userTest";
+        var userInfo = getUserInfo(1, username);
+
+        given(userAccountQueryService.getUserAccountInfo(username)).willReturn(userInfo);
+
         // When & Then
         mvc.perform(get("/accounts/me"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("users/user-info"))
-                .andExpect(model().attributeExists("userInfo"))
-                .andDo(print());
+                .andExpect(model().attributeExists("userInfo"));
+
+        then(userAccountQueryService).should().getUserAccountInfo(anyString());
     }
 
     @DisplayName("[실패][view][GET] Account me 페이지 - 인증되지 않은 사용자")
     @Test
-    void givenNothingWithUnAuthenticatedUser_whenRequestingMeView_thenRedirectsToLoginView() throws Exception {
+    void givenNothingNotAuthenticatedUser_whenRequestingMeView_thenRedirectsToLoginView() throws Exception {
         // Given
         // When & Then
         mvc.perform(get("/accounts/me"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("**/login"))
-                .andDo(print());
+                .andExpect(redirectedUrlPattern("**/login"));
     }
 
     @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -77,13 +100,19 @@ class UserAccountViewControllerTest {
     @Test
     void givenNothingWithRoleUserAccount_whenRequestingMeEditView_thenReturnsMeEditView() throws Exception {
         // Given
+        var username = "userTest";
+        var userInfo = getUserInfo(1, username);
+
+        given(userAccountQueryService.getUserAccountInfo(username)).willReturn(userInfo);
+
         // When & Then
         mvc.perform(get("/accounts/me/edit"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("users/edit-form"))
-                .andExpect(model().attributeExists("updateForm"))
-                .andDo(print());
+                .andExpect(model().attributeExists("updateForm"));
+
+        then(userAccountQueryService).should().getUserAccountInfo(anyString());
     }
 
     @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -92,13 +121,19 @@ class UserAccountViewControllerTest {
     void givenUsernameWithAuthorizedUserAccount_whenRequestingUserInfoView_thenReturnsUserInfoView() throws Exception {
         // Given
         var username = "userTest";
+        var principalUsername = "userTest";
+        var userInfo = getUserInfo(1, username);
+
+        given(userAccountQueryService.getUserAccountInfo(username, principalUsername)).willReturn(userInfo);
+
         // When & Then
         mvc.perform(get("/accounts/" + username))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("users/user-info"))
-                .andExpect(model().attributeExists("userInfo"))
-                .andDo(print());
+                .andExpect(model().attributeExists("userInfo"));
+
+        then(userAccountQueryService).should().getUserAccountInfo(anyString(), anyString());
     }
 
     @WithUserDetails(value = "adminTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -107,26 +142,40 @@ class UserAccountViewControllerTest {
     void givenUsernameWithAdminAccount_whenRequestingUserInfoView_thenReturnsUserInfoView() throws Exception {
         // Given
         var username = "userTest";
+        var principalUsername = "adminTest";
+
+        var userInfo = getUserInfo(1, username);
+
+        given(userAccountQueryService.getUserAccountInfo(username, principalUsername)).willReturn(userInfo);
+
         // When & Then
         mvc.perform(get("/accounts/" + username))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("users/user-info"))
-                .andExpect(model().attributeExists("userInfo"))
-                .andDo(print());
+                .andExpect(model().attributeExists("userInfo"));
+
+        then(userAccountQueryService).should().getUserAccountInfo(anyString(), anyString());
     }
 
-    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest2", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][view][GET] {username}의 회원정보 페이지 - {username}과 다른 인증된 사용자(ROLE_USER)")
     @Test
     void givenUsernameWithUnAuthorizedUserAccount_whenRequestingUserInfoView_thenRedirectsToLoginPage() throws Exception {
         // Given
-        var username = "userTest2";
+        var username = "userTest";
+        var principalUsername = "userTest2";
+
+        given(userAccountQueryService.getUserAccountInfo(username, principalUsername))
+                .willThrow(NoAuthorityToUpdateDeleteException.class);
+
         // When & Then
         mvc.perform(get("/accounts/" + username))
                 .andExpect(status().isForbidden())
                 .andExpect(forwardedUrl("/error/denied"))
                 .andReturn();
+
+        then(userAccountQueryService).shouldHaveNoInteractions();
     }
 
     @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -135,25 +184,51 @@ class UserAccountViewControllerTest {
     void givenUsernameWithAuthorizedUserAccount_whenRequestingUserInfoEditView_thenReturnsUserInfoEditView() throws Exception {
         // Given
         var username = "userTest";
+        var principalUsername = "userTest";
+
+        var userInfo = getUserInfo(1, username);
+
+        given(userAccountQueryService.getUserAccountInfo(username, principalUsername)).willReturn(userInfo);
+
         // When & Then
         mvc.perform(get("/accounts/" + username + "/edit"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("users/edit-form"))
-                .andExpect(model().attributeExists("updateForm"))
-                .andDo(print());
+                .andExpect(model().attributeExists("updateForm"));
+
+        then(userAccountQueryService).should().getUserAccountInfo(anyString(), anyString());
     }
 
-    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @WithUserDetails(value = "userTest2", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[실패][view][GET] {username}의 회원정보 수정 페이지 - {username}과 다른 인증된 사용자(ROLE_USER)")
     @Test
     void givenUsernameWithUnAuthorizedUserAccount_whenRequestingUserInfoEditView_thenRedirectsToErrorPage() throws Exception {
         // Given
-        var username = "userTest2";
+        var username = "userTest";
+        var principalUsername = "userTest2";
+
+        given(userAccountQueryService.getUserAccountInfo(username, principalUsername))
+                .willThrow(NoAuthorityToUpdateDeleteException.class);
+
         // When & Then
         mvc.perform(get("/accounts/" + username + "/edit"))
                 .andExpect(status().isForbidden())
-                .andExpect(forwardedUrl("/error/denied"))
-                .andReturn();
+                .andExpect(forwardedUrl("/error/denied"));
+
+        then(userAccountQueryService).shouldHaveNoInteractions();
+    }
+
+    private static UserAccountInfo getUserInfo(int num, String username) {
+        return UserAccountInfo.builder()
+                .username(username)
+                .userId((long) num)
+                .email(username + "@gmail.com")
+                .name("테스트유저" + num)
+                .phoneNumber(String.format("010-%d%d%d%d-%d000", num, num, num, num, num))
+                .role(UserAccount.RoleType.USER.getRoleValue())
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build();
     }
 }


### PR DESCRIPTION
1. WebMvcTest로 변환하기 위한 선처리 작업
* WebMvcTest 에서 Test 전용 stub UserAccount 엔티티를 사용하기 위해 TestSecurityConfig 작성.
* TestSecurityConfig에 기존 SecurityConfig를 Import함.
* UserDetailsService 구현 클래스인 PrincipalUserDetailsService에  @Service를 제거하고 SecurityConfig에 @Bean으로 등록해 WebMvcTest에서 SecurityConfig Import로 UserDetailsService를 인식할 수 있도록 함.

2. Controller Test를 @WebMvcTest로 변환
* 기존에 @SpringBootTest로 작성했던 Controller Test를 조금더 단위적이고 가벼운 @WebMvcTest로 변환 작업.
* BDDMockito 의 given을 활용한 stub과 then을 통한 확인 작업을 통해 Test 검증함.

3. 줄 간격 수정 업데이트 
* ArticleCommentDto 내부 클래스간 줄간격 수정 업데이트.

This closes #14