### PR TITLE
'좋아요'(Like) 도메인 생성 및 '좋아요' 기능 구현 및 테스트 작성

### DIFF
--- a/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleQueryService.java
@@ -11,7 +11,7 @@ public interface ArticleQueryService {
 
     ArticleInfo.MainInfo getArticle(Long articleId);
 
-    ArticleInfo.ArticleWithCommentsInfo getArticleWithComments(Long articleId);
+    ArticleInfo.ArticleWithCommentsInfo getArticleWithComments(Long articleId, String principalUsername);
 
     Page<ArticleInfo.MainInfo> articles(ArticleCommand.SearchCondition condition, Pageable pageable);
 

--- a/src/main/java/com/example/projectboard/application/likes/LikeCommandService.java
+++ b/src/main/java/com/example/projectboard/application/likes/LikeCommandService.java
@@ -1,0 +1,6 @@
+package com.example.projectboard.application.likes;
+
+public interface LikeCommandService {
+
+    void pushLike(Long articleId, String username);
+}

--- a/src/main/java/com/example/projectboard/application/likes/LikeCommandServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/likes/LikeCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package com.example.projectboard.application.likes;
+
+import com.example.projectboard.common.exception.EntityNotFoundException;
+import com.example.projectboard.common.exception.UsernameNotFoundException;
+import com.example.projectboard.domain.articles.ArticleRepository;
+import com.example.projectboard.domain.likes.Like;
+import com.example.projectboard.domain.likes.LikeRepository;
+import com.example.projectboard.domain.users.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class LikeCommandServiceImpl implements LikeCommandService {
+
+    private final LikeRepository likeRepository;
+    private final ArticleRepository articleRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    @Transactional
+    @Override
+    public void pushLike(Long articleId, String principalUsername) {
+        log.info("{}:{}", getClass().getSimpleName(), "pushLike(Long, String)");
+
+        // 게시글(Article) 엔티티 조회
+        var article = articleRepository.findById(articleId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        // 작성자(UserAccount) 엔티티 조회
+        var userAccount = userAccountRepository.findByUsername(principalUsername).orElseThrow(() ->
+                new UsernameNotFoundException("유저를 찾을 수 없습니다. username=" + principalUsername));
+
+        // 좋아요가 눌러있는 상태 -> 좋아요 취소, 그렇지 않다면 Like 엔티티 생성 후 저장!
+        var like = alreadyPushedLike(articleId, userAccount.getId());
+
+        if (like.isPresent()) {
+            log.info("already pushed LIKE then delete entity");
+            likeRepository.delete(like.get());
+        } else {
+            log.info("saving new LIKE entity");
+            likeRepository.save(Like.of(userAccount, article));
+        }
+    }
+
+    private Optional<Like> alreadyPushedLike(Long articleId, Long userId) {
+        log.info("이미 눌린 '좋아요'인지 체크하는 로직 실행");
+        return likeRepository.findByArticle_IdAndUserAccount_Id(articleId, userId);
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
@@ -72,8 +72,10 @@ public class ArticleInfo {
         private String createdBy;
         private LocalDateTime createdAt;
         private List<ArticleCommentInfo.SimpleInfo> comments;
+        private boolean likedArticle;
         public ArticleWithCommentsInfo(Article entity,
-                                       List<ArticleCommentInfo.SimpleInfo> comments) {
+                                       List<ArticleCommentInfo.SimpleInfo> comments,
+                                       boolean likedArticle) {
 
             this.articleId = entity.getId();
             this.userId = entity.getUserId();
@@ -90,6 +92,8 @@ public class ArticleInfo {
             if (comments != null && comments.size() > 0) {
                 this.comments.addAll(comments);
             }
+
+            this.likedArticle = likedArticle;
         }
     }
 

--- a/src/main/java/com/example/projectboard/domain/likes/Like.java
+++ b/src/main/java/com/example/projectboard/domain/likes/Like.java
@@ -1,0 +1,37 @@
+package com.example.projectboard.domain.likes;
+
+import com.example.projectboard.domain.JpaAuditingDateTimeFields;
+import com.example.projectboard.domain.articles.Article;
+import com.example.projectboard.domain.users.UserAccount;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "likes")
+@Entity
+public class Like extends JpaAuditingDateTimeFields {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserAccount userAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    private Like(UserAccount userAccount, Article article) {
+        this.userAccount = userAccount;
+        this.article = article;
+    }
+
+    public static Like of(UserAccount userAccount, Article article) {
+        return new Like(userAccount, article);
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/likes/LikeRepository.java
+++ b/src/main/java/com/example/projectboard/domain/likes/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.example.projectboard.domain.likes;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByArticle_IdAndUserAccount_Id(Long articleId, Long userId);
+
+    Optional<Like> findByArticle_IdAndUserAccount_Username(Long articleId, String username);
+
+    boolean existsByArticle_IdAndUserAccount_Username(Long articleId, String username);
+}

--- a/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
@@ -144,6 +144,7 @@ public class ArticleDto {
         private String createdBy;
         private LocalDateTime createdAt;
         private List<CommentInfoResponse> comments;
+        private boolean likedArticle;
     }
 
     @Getter

--- a/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
@@ -6,12 +6,14 @@ import com.example.projectboard.domain.articles.SearchType;
 import com.example.projectboard.interfaces.dto.articlecomments.ArticleCommentDto;
 import com.example.projectboard.interfaces.dto.articles.ArticleDto;
 import com.example.projectboard.interfaces.dto.articles.ArticleDtoMapper;
+import com.example.projectboard.security.PrincipalUserAccount;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -69,9 +71,12 @@ public class ArticleViewController {
     }
 
     @GetMapping("/{id}")
-    public String articleDetail(@PathVariable Long id, Model model) {
+    public String articleDetail(@PathVariable Long id,
+                                @AuthenticationPrincipal PrincipalUserAccount principalUserAccount,
+                                Model model) {
 
-        var article = articleDtoMapper.toDto(articleQueryService.getArticleWithComments(id));
+        var article
+                = articleDtoMapper.toDto(articleQueryService.getArticleWithComments(id, (principalUserAccount != null) ? principalUserAccount.getUsername() : null));
         var registerForm = ArticleCommentDto.RegisterForm.builder().parentArticleId(id).build();
 
         model.addAttribute("article", article);

--- a/src/main/java/com/example/projectboard/interfaces/web/likes/LikeCommandController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/likes/LikeCommandController.java
@@ -1,0 +1,29 @@
+package com.example.projectboard.interfaces.web.likes;
+
+import com.example.projectboard.application.likes.LikeCommandService;
+import com.example.projectboard.security.PrincipalUserAccount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class LikeCommandController {
+
+    private final LikeCommandService likeCommandService;
+
+    @PreAuthorize("isAuthenticated() and hasAnyRole({'ROLE_USER', 'ROLE_ADMIN'})")
+    @PostMapping("/likes/{articleId}")
+    public String pushLike(@PathVariable Long articleId,
+                           @AuthenticationPrincipal PrincipalUserAccount principalUserAccount) {
+
+        likeCommandService.pushLike(articleId, principalUserAccount.getUsername());
+
+        return "redirect:/articles/" + articleId;
+    }
+}

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -32,7 +32,16 @@
                           th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2022-01-01
                     </time>
                 </p>
-                <p th:if="${article.hashtagInfos != null and article.hashtagInfos.size() > 0}" th:each="hashtag : ${article.hashtagInfos}">
+                <p>
+                    <form th:method="post" th:action="@{/likes/{id}(id=${article.articleId})}">
+                        <button th:if="${#authentication.isAuthenticated()} and ${#authorization.expression('hasRole(''ROLE_USER'')')} and ${article.likedArticle == true}"
+                            type="submit" class="btn btn-danger btn-sm">좋아요</button>
+                        <button th:unless="${#authentication.isAuthenticated()} and ${#authorization.expression('hasRole(''ROLE_USER'')')} and ${article.likedArticle == true}"
+                            type="submit" class="btn btn-outline-danger btn-sm">좋아요</button>
+                    </form>
+                </p>
+                <p th:if="${article.hashtagInfos != null and article.hashtagInfos.size() > 0}"
+                   th:each="hashtag : ${article.hashtagInfos}">
                     <span class="badge text-bg-secondary mx-1">
                         <a class="text-reset" th:text="${hashtag.actualHashtagName}" th:href="@{#}">#java</a>
                     </span>
@@ -45,7 +54,8 @@
         </article>
     </div>
 
-    <div class="row g-5 ms-lg-5 mt-2" id="article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and ${article.createdBy} == ${#authentication.name}">
+    <div class="row g-5 ms-lg-5 mt-2" id="article-buttons"
+         th:if="${#authorization.expression('isAuthenticated()')} and ${article.createdBy} == ${#authentication.name}">
         <form id="delete-article-form" th:action="@{/articles/{id}(id=${article.articleId})}" th:method="post">
             <input type="hidden" name="_method" value="delete"/>
             <div class="pb-5 d-grid gap-2 d-md-block ms-4">
@@ -58,11 +68,13 @@
 
     <div class="row g-5 ms-lg-5 mt-4">
         <section class="ms-4">
-            <form class="row g-3" id="comment-form" th:action="@{/article-comments}" th:method="post" th:object="${registerForm}">
+            <form class="row g-3" id="comment-form" th:action="@{/article-comments}" th:method="post"
+                  th:object="${registerForm}">
                 <div class="col-md-9 col-lg-8">
                     <input type="hidden" class="article-id" name="articleId" th:field="*{parentArticleId}">
                     <label for="comment-textbox" hidden>댓글</label>
-                    <textarea class="form-control" id="comment-textbox" th:field="*{commentBody}" placeholder="댓글 쓰기.." rows="3" required></textarea>
+                    <textarea class="form-control" id="comment-textbox" th:field="*{commentBody}" placeholder="댓글 쓰기.."
+                              rows="3" required></textarea>
                 </div>
                 <div class="col-md-9 col-lg-8">
                     <label for="comment-textbox" hidden></label>
@@ -78,7 +90,8 @@
 
             <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3 mt-2" th:each="comment : ${article.comments}">
                 <li>
-                    <form class="comment-form" th:action="@{/article-comments/{id}(id=${comment.commentId})}" th:method="post">
+                    <form class="comment-form" th:action="@{/article-comments/{id}(id=${comment.commentId})}"
+                          th:method="post">
                         <input type="hidden" name="_method" value="delete"/>
                         <input type="hidden" class="article-id" name="articleId" th:value="${article.articleId}">
                         <div class="row">

--- a/src/test/java/com/example/projectboard/application/likes/LikeCommandServiceTest.java
+++ b/src/test/java/com/example/projectboard/application/likes/LikeCommandServiceTest.java
@@ -1,0 +1,55 @@
+package com.example.projectboard.application.likes;
+
+import com.example.projectboard.domain.likes.LikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class LikeCommandServiceTest {
+
+    @Autowired
+    private LikeCommandService sut;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[성공][service] '좋아요' 누르기 기능 테스트 - 눌린적 없는 푸쉬")
+    @Test
+    void givenArticleIdAndUsername_whenPushLike_thenSavesNewLikeEntity() {
+        //given
+        var articleId = 1L;
+        var principalUsername = "userTest";
+
+        //when
+        sut.pushLike(articleId, principalUsername);
+
+        //then
+        var findLike = likeRepository.findByArticle_IdAndUserAccount_Username(articleId, principalUsername);
+        assertThat(findLike).isPresent();
+    }
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[성공][service] '좋아요' 누르기 기능 테스트 - 이미 눌렸던 '좋아요' 푸쉬")
+    @Test
+    void givenAlreadyPushedArticleIdAndUsername_whenPushLike_thenDeleteLikeEntity() {
+        //given
+        var articleId = 2L;
+        var principalUsername = "userTest";
+
+        sut.pushLike(articleId, principalUsername);
+
+        //when
+        sut.pushLike(articleId, principalUsername);
+
+        //then
+        var findLike = likeRepository.findByArticle_IdAndUserAccount_Username(articleId, principalUsername);
+        assertThat(findLike).isNotPresent();
+    }
+}

--- a/src/test/java/com/example/projectboard/interfaces/web/likes/LikeCommandControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/likes/LikeCommandControllerTest.java
@@ -1,0 +1,88 @@
+package com.example.projectboard.interfaces.web.likes;
+
+import com.example.projectboard.application.likes.LikeCommandService;
+import com.example.projectboard.config.TestSecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(TestSecurityConfig.class)
+@AutoConfigureMockMvc
+@WebMvcTest(controllers = LikeCommandController.class)
+class LikeCommandControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LikeCommandService likeCommandService;
+
+    @Test
+    @DisplayName("[실패][controller] '좋아요' 등록 테스트 - 인증되지 않은 사용자일 경우 로그인 페이지로 이동")
+    void givenArticleIdAndPrincipalUsernameWithNotAuthenticatedUser_WhenPostingLike_thenRedirectToLoginPage() throws Exception {
+        //given
+        var articleId = 1L;
+        var principalUsername = "userTest";
+
+        willDoNothing().given(likeCommandService).pushLike(eq(articleId), eq(principalUsername));
+
+        //when
+        mvc.perform(post("/likes/" + articleId).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        //then
+        then(likeCommandService).shouldHaveNoInteractions();
+    }
+
+    @WithUserDetails(value = "userTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    @DisplayName("[성공][controller] '좋아요' 등록 테스트")
+    void givenArticleIdAndPrincipalUsername_WhenPostingLike_thenSaveLikeAndRedirectToDetailPage() throws Exception {
+        //given
+        var articleId = 1L;
+        var principalUsername = "userTest";
+
+        willDoNothing().given(likeCommandService).pushLike(eq(articleId), eq(principalUsername));
+
+        //when
+        mvc.perform(post("/likes/" + articleId).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId));
+
+        //then
+        then(likeCommandService).should().pushLike(eq(articleId), eq(principalUsername));
+    }
+
+    @WithUserDetails(value = "userTest2", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    @DisplayName("[성공][controller] '좋아요' 등록 테스트 - 이미 눌렀던 '좋아요' 버튼")
+    void givenAlreadyPushedLikeInfo_WhenPostingLike_thenDeleteLikeAndRedirectToDetailPage() throws Exception {
+        //given
+        var articleId = 2L;
+        var principalUsername = "userTest2";
+
+        willDoNothing().given(likeCommandService).pushLike(eq(articleId), eq(principalUsername));
+
+        //when
+        mvc.perform(post("/likes/" + articleId).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/articles/" + articleId));
+
+        //then
+        then(likeCommandService).should().pushLike(eq(articleId), eq(principalUsername));
+    }
+}

--- a/src/test/resources/data-test.sql
+++ b/src/test/resources/data-test.sql
@@ -142,3 +142,6 @@ insert into article_hashtags (actual_hashtag_name, article_id, hashtag_id, creat
 insert into article_hashtags (actual_hashtag_name, article_id, hashtag_id, created_at, modified_at) values ('#turquoise', 1, 3, '2022-02-25 19:53:06', '2022-02-27 19:53:06');
 insert into article_hashtags (actual_hashtag_name, article_id, hashtag_id, created_at, modified_at) values ('#Puce', 2, 4, '2022-02-11 21:04:52', '2022-02-13 21:04:52');
 insert into article_hashtags (actual_hashtag_name, article_id, hashtag_id, created_at, modified_at) values ('#Yellow', 3, 5, '2022-06-15 10:45:48', '2022-06-17 10:45:48');
+
+-- Likes TABLE INSERT --
+insert into likes (article_id, user_id, created_at, modified_at) values (2L, 2L, '2022-10-24 10:45:48', '2022-10-24 10:45:48');


### PR DESCRIPTION
* '좋아요'(Like) 엔티티 클래스 작성함 --> 'Article' 과 다대일 단방향 매핑, 'UserAccount' 와 다대일 단방향 매핑함.
* LikeCommmadService에 pushLike() 로직 구현함 --> 이미 눌린 '좋아요'인 경우, '좋아요' 취소, 아닐 경우는 '좋아요' push 생성.
* ArticleDatail 로직에 로그인된 사용자일 경우, 본인이 해당 게시글에 '좋아요'를 누른 게시글에 표시하기 위한 로직 구현.
* detail.html에 '좋아요' 버튼 구현함.
* Controller 및 Service Test를 작성함으로써 로직이 정상적으로 작동하는지 체크함.

This closes #16