### PR TITLE
조회수 증가 로직 구현 및 조회수 중복 방지 기능 추가

### DIFF
--- a/src/main/java/com/example/projectboard/application/articles/ArticleCommandService.java
+++ b/src/main/java/com/example/projectboard/application/articles/ArticleCommandService.java
@@ -3,11 +3,16 @@ package com.example.projectboard.application.articles;
 import com.example.projectboard.domain.articles.ArticleCommand;
 import com.example.projectboard.domain.articles.ArticleInfo;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 public interface ArticleCommandService {
 
     ArticleInfo.MainInfo registerArticle(String principalUsername, ArticleCommand.RegisterReq command);
 
     ArticleInfo.MainInfo registerArticleWithValidHashtags(String principalUsername, ArticleCommand.RegisterReq command);
+
+    void viewCountUp(Long articleId, HttpServletRequest request, HttpServletResponse response);
 
     void update(Long articleId, String principalUsername, ArticleCommand.UpdateReq command);
 

--- a/src/main/java/com/example/projectboard/domain/articles/Article.java
+++ b/src/main/java/com/example/projectboard/domain/articles/Article.java
@@ -32,6 +32,9 @@ public class Article extends JpaAuditingFields {
     @Column(nullable = false, length = 10000)
     private String content; // 본문
 
+    @Column(columnDefinition = "integer default 0", nullable = false)
+    private Integer viewCount;
+
     @Column(nullable = false, updatable = false)
     private Long userId; // 연관관계 매핑: UserAccount id
 

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleInfo.java
@@ -23,6 +23,7 @@ public class ArticleInfo {
         private Long userId;
         private String title;
         private String content;
+        private Integer viewCount;
         private Set<HashtagInfo> hashtagInfos;
         private String createdBy;
         private LocalDateTime createdAt;
@@ -32,6 +33,7 @@ public class ArticleInfo {
             this.userId = entity.getUserId();
             this.title = entity.getTitle();
             this.content = entity.getContent();
+            this.viewCount = entity.getViewCount();
             this.createdBy = entity.getCreatedBy();
             this.createdAt = entity.getCreatedAt();
             this.hashtagInfos = entity.getHashtags().stream()
@@ -44,6 +46,7 @@ public class ArticleInfo {
             this.userId = entity.getUserId();
             this.title = entity.getTitle();
             this.content = entity.getContent();
+            this.viewCount = entity.getViewCount();
             this.createdBy = entity.getCreatedBy();
             this.createdAt = entity.getCreatedAt();
             this.hashtagInfos = hashtags.stream()
@@ -68,6 +71,7 @@ public class ArticleInfo {
         private Long userId;
         private String title;
         private String content;
+        private Integer viewCount;
         private List<HashtagInfo> hashtagInfos;
         private String createdBy;
         private LocalDateTime createdAt;
@@ -81,6 +85,7 @@ public class ArticleInfo {
             this.userId = entity.getUserId();
             this.title = entity.getTitle();
             this.content = entity.getContent();
+            this.viewCount = entity.getViewCount();
             this.createdBy = entity.getCreatedBy();
             this.createdAt = entity.getCreatedAt();
 

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleRepository.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleRepository.java
@@ -11,5 +11,9 @@ public interface ArticleRepository extends
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Article a WHERE a.userId = :userId")
     void bulkDeleteByUserAccount_Id(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("update Article a set a.viewCount = a.viewCount + 1 where a.id = :articleId")
+    void updateViewCount(@Param("articleId") Long articleId);
 }
 

--- a/src/main/java/com/example/projectboard/domain/articles/ArticleRepositoryImpl.java
+++ b/src/main/java/com/example/projectboard/domain/articles/ArticleRepositoryImpl.java
@@ -116,6 +116,8 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                         return new OrderSpecifier<>(direction, article.id);
                     case "title":
                         return new OrderSpecifier<>(direction, article.title);
+                    case "viewCount":
+                        return new OrderSpecifier<>(direction, article.viewCount);
                     case "createdBy":
                         return new OrderSpecifier<>(direction, article.createdBy);
                     case "createdAt":

--- a/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
+++ b/src/main/java/com/example/projectboard/interfaces/dto/articles/ArticleDto.java
@@ -138,6 +138,7 @@ public class ArticleDto {
         private Long userId;
         private String title;
         private String content;
+        private Integer viewCount;
         private List<HashtagInfoResponse> hashtagInfos;
         private String createdBy;
         private LocalDateTime createdAt;
@@ -151,6 +152,7 @@ public class ArticleDto {
         private Long userId;
         private String title;
         private String content;
+        private Integer viewCount;
         private List<HashtagInfoResponse> hashtagInfos;
         private String createdBy;
         private LocalDateTime createdAt;

--- a/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
+++ b/src/main/java/com/example/projectboard/interfaces/web/articles/ArticleViewController.java
@@ -1,6 +1,7 @@
 package com.example.projectboard.interfaces.web.articles;
 
 import com.example.projectboard.application.PaginationService;
+import com.example.projectboard.application.articles.ArticleCommandService;
 import com.example.projectboard.application.articles.ArticleQueryService;
 import com.example.projectboard.application.likes.ArticleLikeQueryService;
 import com.example.projectboard.domain.articles.SearchType;
@@ -19,6 +20,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 @Slf4j
@@ -29,6 +32,7 @@ import java.util.List;
 public class ArticleViewController {
 
     private final ArticleQueryService articleQueryService;
+    private final ArticleCommandService articleCommandService;
     private final ArticleLikeQueryService articleLikeQueryService;
     private final PaginationService paginationService;
     private final ArticleDtoMapper articleDtoMapper;
@@ -121,11 +125,16 @@ public class ArticleViewController {
     @GetMapping("/{id}")
     public String articleDetail(@PathVariable Long id,
                                 @AuthenticationPrincipal PrincipalUserAccount principalUserAccount,
+                                HttpServletRequest request,
+                                HttpServletResponse response,
                                 Model model) {
 
         var article
                 = articleDtoMapper.toDto(articleQueryService.getArticleWithComments(id, (principalUserAccount != null) ? principalUserAccount.getUsername() : null));
         var registerForm = ArticleCommentDto.RegisterForm.builder().parentArticleId(id).build();
+
+        // 모든 조회 로직 후 조회수 증가 로직 실행
+        articleCommandService.viewCountUp(id, request, response);
 
         model.addAttribute("article", article);
         model.addAttribute("registerForm", registerForm);

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -32,6 +32,7 @@
                           th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2022-01-01
                     </time>
                 </p>
+                <p><span>조회수</span>&nbsp;<span id="viewCount" th:text="${article.viewCount}">0</span></p>
                 <p>
                     <form th:method="post" th:action="@{/likes/{id}(id=${article.articleId})}">
                         <button th:if="${#authentication.isAuthenticated()} and ${#authorization.expression('hasRole(''ROLE_USER'')')} and ${article.likedArticle == true}"

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -105,6 +105,14 @@
                        searchType=${param.searchType},
                        searchValue=${param.searchValue})}">제목 사전순</a>
                 </li>
+                <li th:with="viewCountDesc=${articles.sort.getOrderFor('viewCount')} != null and ${articles.sort.getOrderFor('viewCount').direction.name} == 'DESC'">
+                    <a th:class="'dropdown-item' + (${viewCountDesc} ? ' active' : '')" th:aria-current="${viewCountDesc}"
+                       th:href="@{/articles(
+                       page=${articles.number},
+                       sort='viewCount,DESC',
+                       searchType=${param.searchType},
+                       searchValue=${param.searchValue})}">조회수 높은순</a>
+                </li>
             </ul>
         </div>
     </div>
@@ -115,6 +123,7 @@
                 <th class="title col-6"><a>제목</a></th>
                 <th class="hashtag col-2"><a>해시태그</a></th>
                 <th class="user-id"><a>작성자</a></th>
+                <th class="viewCount"><a>조회수</a></th>
                 <th class="created-at"><a>작성일</a></th>
             </tr>
             </thead>
@@ -127,6 +136,7 @@
                        th:text="${hashtag.actualHashtagName}" th:href="@{/articles/hashtag-search/{hashtagId}(hashtagId=${hashtag.hashtagId})}">#java</a>
                 </td>
                 <td class="user-id" th:text="${article.createdBy}">Uno</td>
+                <td class="viewCount" th:text="${article.viewCount}">0</td>
                 <td class="created-at" th:datetime="${article.createdAt}"
                     th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd')}">
                     <time>2022-01-01</time>

--- a/src/main/resources/templates/articles/liked.html
+++ b/src/main/resources/templates/articles/liked.html
@@ -108,6 +108,14 @@
                        searchType=${param.searchType},
                        searchValue=${param.searchValue})}">제목 사전순</a>
                 </li>
+                <li th:with="viewCountDesc=${articles.sort.getOrderFor('viewCount')} != null and ${articles.sort.getOrderFor('viewCount').direction.name} == 'DESC'">
+                    <a th:class="'dropdown-item' + (${viewCountDesc} ? ' active' : '')" th:aria-current="${viewCountDesc}"
+                       th:href="@{/articles/liked(
+                       page=${articles.number},
+                       sort='viewCount,DESC',
+                       searchType=${param.searchType},
+                       searchValue=${param.searchValue})}">조회수 높은순</a>
+                </li>
             </ul>
         </div>
     </div>
@@ -118,6 +126,7 @@
                 <th class="title col-6"><a>제목</a></th>
                 <th class="hashtag col-2"><a>해시태그</a></th>
                 <th class="user-id"><a>작성자</a></th>
+                <th class="viewCount"><a>조회수</a></th>
                 <th class="created-at"><a>작성일</a></th>
             </tr>
             </thead>
@@ -130,6 +139,7 @@
                        th:text="${hashtag.actualHashtagName}" th:href="@{/articles/hashtag-search/{hashtagId}(hashtagId=${hashtag.hashtagId})}">#java</a>
                 </td>
                 <td class="user-id" th:text="${article.createdBy}">Uno</td>
+                <td class="viewCount" th:text="${article.viewCount}">0</td>
                 <td class="created-at" th:datetime="${article.createdAt}"
                     th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd')}">
                     <time>2022-01-01</time>

--- a/src/main/resources/templates/articles/written-by-me.html
+++ b/src/main/resources/templates/articles/written-by-me.html
@@ -108,6 +108,14 @@
                        searchType=${param.searchType},
                        searchValue=${param.searchValue})}">제목 사전순</a>
         </li>
+        <li th:with="viewCountDesc=${articles.sort.getOrderFor('viewCount')} != null and ${articles.sort.getOrderFor('viewCount').direction.name} == 'DESC'">
+          <a th:class="'dropdown-item' + (${viewCountDesc} ? ' active' : '')" th:aria-current="${viewCountDesc}"
+             th:href="@{/articles/by-me(
+                       page=${articles.number},
+                       sort='viewCount,DESC',
+                       searchType=${param.searchType},
+                       searchValue=${param.searchValue})}">조회수 높은순</a>
+        </li>
       </ul>
     </div>
   </div>
@@ -118,6 +126,7 @@
         <th class="title col-6"><a>제목</a></th>
         <th class="hashtag col-2"><a>해시태그</a></th>
         <th class="user-id"><a>작성자</a></th>
+        <th class="viewCount"><a>조회수</a></th>
         <th class="created-at"><a>작성일</a></th>
       </tr>
       </thead>
@@ -130,6 +139,7 @@
              th:text="${hashtag.actualHashtagName}" th:href="@{/articles/hashtag-search/{hashtagId}(hashtagId=${hashtag.hashtagId})}">#java</a>
         </td>
         <td class="user-id" th:text="${article.createdBy}">Uno</td>
+        <td class="viewCount" th:text="${article.viewCount}">0</td>
         <td class="created-at" th:datetime="${article.createdAt}"
             th:text="*{#temporals.format(article.createdAt, 'yyyy-MM-dd')}">
           <time>2022-01-01</time>

--- a/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleViewControllerTest.java
+++ b/src/test/java/com/example/projectboard/interfaces/web/articles/ArticleViewControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.projectboard.interfaces.web.articles;
 
 import com.example.projectboard.application.PaginationService;
+import com.example.projectboard.application.articles.ArticleCommandService;
 import com.example.projectboard.application.articles.ArticleQueryService;
 import com.example.projectboard.application.likes.ArticleLikeQueryService;
 import com.example.projectboard.config.TestSecurityConfig;
@@ -50,6 +51,9 @@ public class ArticleViewControllerTest {
 
     @MockBean
     private ArticleQueryService articleQueryService;
+
+    @MockBean
+    private ArticleCommandService articleCommandService;
 
     @MockBean
     private ArticleLikeQueryService articleLikeQueryService;


### PR DESCRIPTION
* Article/ArticleInfo/ArticleDto 클래스에 viewCount 필드 추가함.
* ArticleRepository에 updateViewCount(Long articleId) 쿼리 JPQL로 구현.
* ArticleCommandService에 쿠키를 사용한 조회수 중복 방지 및 조회수 증가 로직 구현.
* ArticleViewController에 ArticleCommandService 의존성 주입 후 게시물 단건 조회 요청 로직에 조회수 증가 서비스 로직 호출함.
* ArticleViewControllerTest에 추가 주입된 ArticleCommandService @MockBean으로 추가함.

This closes #20