### PR TITLE
게시글 삭제에 따른 삽입된 파일 전체 삭제 로직 추가 

### DIFF
--- a/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceImpl.java
+++ b/src/main/java/com/example/projectboard/application/articlecomments/ArticleCommentCommandServiceImpl.java
@@ -103,7 +103,7 @@ public class ArticleCommentCommandServiceImpl implements ArticleCommentCommandSe
         if (validateAuthorityToCommand(comment.getUserId(), principalUsername)) {
 
             if (comment.hasChilds()) { // 자식 댓글 존재 여부 확인 후, 자식 댓글을 먼저 모두 삭제한다.
-                articleCommentRepository.deleteByParentId(commentId);
+                articleCommentRepository.bulkDeleteByParentId(commentId);
             }
 
             // 댓글 삭제

--- a/src/main/java/com/example/projectboard/application/uploadfiles/ArticleAttachedFileStorageService.java
+++ b/src/main/java/com/example/projectboard/application/uploadfiles/ArticleAttachedFileStorageService.java
@@ -1,4 +1,4 @@
-package com.example.projectboard.application;
+package com.example.projectboard.application.uploadfiles;
 
 import com.example.projectboard.infra.storage.ResourceStorage;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,9 @@ public class ArticleAttachedFileStorageService implements FileStorageService {
         log.info("uploading multipartFile.... filename: {}", multipartFile.getOriginalFilename());
 
         validateFileExists(multipartFile);
-        return storage.upload(multipartFile, createStoreFilename(multipartFile.getOriginalFilename()));
+        var storeFilename = createStoreFilename(multipartFile.getOriginalFilename());
+
+        return storage.upload(multipartFile, storeFilename);
     }
 
     @Override

--- a/src/main/java/com/example/projectboard/application/uploadfiles/FileStorageService.java
+++ b/src/main/java/com/example/projectboard/application/uploadfiles/FileStorageService.java
@@ -1,4 +1,4 @@
-package com.example.projectboard.application;
+package com.example.projectboard.application.uploadfiles;
 
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/example/projectboard/common/util/FilenameExtractUtils.java
+++ b/src/main/java/com/example/projectboard/common/util/FilenameExtractUtils.java
@@ -1,0 +1,29 @@
+package com.example.projectboard.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class FilenameExtractUtils {
+
+    public static List<String> extract(String content) {
+        String imgRegex = "<img[^>]*src=[\"']?([^>\"']+)[\"']?[^>]*>";
+
+        var pattern = Pattern.compile(imgRegex);
+        var matcher = pattern.matcher(content);
+
+        var result = new ArrayList<String>();
+        while (matcher.find()) {
+            var path = matcher.group(1);
+            var filename = path.trim().substring(path.lastIndexOf("/") + 1);
+            log.info("extracted filename = {}", filename);
+
+            result.add(filename);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/example/projectboard/domain/articlecomments/ArticleCommentRepository.java
+++ b/src/main/java/com/example/projectboard/domain/articlecomments/ArticleCommentRepository.java
@@ -19,13 +19,13 @@ public interface ArticleCommentRepository extends
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ArticleComment ac WHERE ac.article.id = :articleId")
-    void deleteByArticleId(@Param("articleId") Long articleId);
+    void bulkDeleteByArticleId(@Param("articleId") Long articleId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ArticleComment ac WHERE ac.userId = :userId")
-    void deleteByUserAccountId(@Param("userId") Long userId);
+    void bulkDeleteByUserAccountId(@Param("userId") Long userId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ArticleComment ac WHERE ac.parent.id = :parentId")
-    void deleteByParentId(@Param("parentId") Long parentId);
+    void bulkDeleteByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/example/projectboard/domain/articles/articlehashtags/ArticleHashtagRepository.java
+++ b/src/main/java/com/example/projectboard/domain/articles/articlehashtags/ArticleHashtagRepository.java
@@ -1,6 +1,5 @@
 package com.example.projectboard.domain.articles.articlehashtags;
 
-import com.example.projectboard.domain.articles.articlehashtags.ArticleHashtag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,9 +20,9 @@ public interface ArticleHashtagRepository
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ArticleHashtag ah WHERE ah.article.id = :articleId")
-    void bulkDeleteByArticle_Id(@Param("articleId") Long articleId);
+    void bulkDeleteByArticleId(@Param("articleId") Long articleId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM ArticleHashtag ah WHERE ah.hashtag.id = :hashtagId")
-    void bulkDeleteByHashtag_Id(@Param("hashtagId") Long hashtagId);
+    void bulkDeleteByHashtagId(@Param("hashtagId") Long hashtagId);
 }

--- a/src/main/java/com/example/projectboard/domain/likes/LikeRepository.java
+++ b/src/main/java/com/example/projectboard/domain/likes/LikeRepository.java
@@ -17,5 +17,5 @@ public interface LikeRepository extends JpaRepository<Like, Long>, LikeRepositor
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Like l WHERE l.article.id = :articleId")
-    void deleteByArticleId(@Param("articleId") Long articleId);
+    void bulkDeleteByArticleId(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/example/projectboard/interfaces/api/v1/files/ArticleAttachedFileApiController.java
+++ b/src/main/java/com/example/projectboard/interfaces/api/v1/files/ArticleAttachedFileApiController.java
@@ -1,6 +1,6 @@
 package com.example.projectboard.interfaces.api.v1.files;
 
-import com.example.projectboard.application.FileStorageService;
+import com.example.projectboard.application.uploadfiles.FileStorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;

--- a/src/main/resources/static/js/articles.js
+++ b/src/main/resources/static/js/articles.js
@@ -17,7 +17,7 @@ function sendFile(file, el) {
         data: form_data,
         success: function (response) {
             $(el).summernote('insertImage', response, function ($image) {
-                $image.css('width', '30%');
+                $image.css('width', '25%');
             });
         }
     });

--- a/src/test/java/com/example/projectboard/domain/JpaRepositoryTest.java
+++ b/src/test/java/com/example/projectboard/domain/JpaRepositoryTest.java
@@ -161,7 +161,7 @@ public class JpaRepositoryTest {
         long previousArticleCommentCount = articleCommentRepository.count();
 
         // When
-        articleCommentRepository.deleteByParentId(1L);
+        articleCommentRepository.bulkDeleteByParentId(1L);
         articleCommentRepository.deleteById(1L);
 
         // Then


### PR DESCRIPTION
* 게시글 수정시 삽입된 이미지를 삭제하는 로직은 정상 동작하나, 게시글 삭제시 삽입된 파일들이 로컬 스토리지에서 삭제되지 않는 에러 발견.
* summernote 에디터에 기반한 html 형식의 게시글 내용에서 삽입된 이미지 파일을 추출하는 유틸리티 클래서 'FilenameExtractUtils' 구현함.
* ArticleCommandService에 FileStorageService 의존성을 주입, delete 메서드에서 FilenameExtractUtils로 추출한 삽입된 파일명 리스트를 반복문을 통해 삭제하는 로직 추가함.
* 그외 코드 리팩토링, 패키지 위치 변경 등 

This closes #25