### PR TITLE
Actuator 보안 설정 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,18 +30,35 @@ spring:
       max-request-size: 100MB
 
 debug: false
-management:
 
+# Actuator 보안 설정 샘플
+
+# Endpoint all disable
+management:
   endpoints:
+    enabled-by-default: false
+# Exclude all endpoint for JMX and Expose specific endpoints
+    jmx:
+      exposure:
+        exclude: "*"
     web:
       exposure:
-        include: "*"
+        include: "info, health"
+
+# Enable specific endpoints
+  endpoint:
+    info:
+      enabled: true
+    health:
+      enabled: true
+# Use other port for Actuator
+  server:
+    port: 7890
+
 logging:
   level:
     com.example.projectboard: debug
     org.springframework.web.servlet: debug
-
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 ---
 spring:


### PR DESCRIPTION
* Actuator 정보가 모두 노출되는 것은 보안상 문제가 될 수 있으므로 최대한 보안에 안전하도록 설정파일에 Actuator 설정을 수정 업데이트함.