### PR TITLE
헤로쿠 오류 수정: Thymeleaf th:replace 경로 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,3 @@ spring:
   sql:
     init:
       mode: always
-
-server:
-  port: $PORT

--- a/src/main/resources/templates/articles/add-form.html
+++ b/src/main/resources/templates/articles/add-form.html
@@ -22,7 +22,7 @@
 
 <body>
 
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -79,7 +79,7 @@
     </form>
 </div>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -13,7 +13,7 @@
 
 <body>
 
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -179,7 +179,7 @@
     </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/edit-form.html
+++ b/src/main/resources/templates/articles/edit-form.html
@@ -21,7 +21,7 @@
 
 <body>
 
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -87,7 +87,7 @@
     </form>
 </div>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/hashtag-search.html
+++ b/src/main/resources/templates/articles/hashtag-search.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -120,7 +120,7 @@
   </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
   <hr>
   푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -181,7 +181,7 @@
     </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/liked.html
+++ b/src/main/resources/templates/articles/liked.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -184,7 +184,7 @@
     </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/articles/written-by-me.html
+++ b/src/main/resources/templates/articles/written-by-me.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -184,7 +184,7 @@
   </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
   <hr>
   푸터 삽입부
 </footer>

--- a/src/main/resources/templates/error/denied-page.html
+++ b/src/main/resources/templates/error/denied-page.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -31,7 +31,7 @@
   </section>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
   <hr>
   푸터 삽입부
 </footer>

--- a/src/main/resources/templates/error/error-page.html
+++ b/src/main/resources/templates/error/error-page.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -29,7 +29,7 @@
   </section>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
   <hr>
   푸터 삽입부
 </footer>

--- a/src/main/resources/templates/hashtags/hashtag-list.html
+++ b/src/main/resources/templates/hashtags/hashtag-list.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="rfragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -87,7 +87,7 @@
   </div>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
   <hr>
   푸터 삽입부
 </footer>

--- a/src/main/resources/templates/users/edit-form.html
+++ b/src/main/resources/templates/users/edit-form.html
@@ -29,7 +29,7 @@
 
 </head>
 <body class="bg-light">
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -98,7 +98,7 @@
         </div>
     </main>
 
-    <footer th:replace="/fragments/footer.html :: footer-config">
+    <footer th:replace="fragments/footer :: footer-config">
         <hr>
         푸터 삽입부
     </footer>

--- a/src/main/resources/templates/users/sign-up-success.html
+++ b/src/main/resources/templates/users/sign-up-success.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -34,7 +34,7 @@
     </section>
 </main>
 
-<footer th:replace="/fragments/footer.html :: footer-config">
+<footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
 </footer>

--- a/src/main/resources/templates/users/sign-up.html
+++ b/src/main/resources/templates/users/sign-up.html
@@ -28,7 +28,7 @@
 
 </head>
 <body class="bg-light">
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
   헤더 삽입부
   <hr>
 </header>
@@ -103,7 +103,7 @@
     </div>
   </main>
 
-  <footer th:replace="/fragments/footer.html :: footer-config">
+  <footer th:replace="fragments/footer :: footer-config">
     <hr>
     푸터 삽입부
   </footer>

--- a/src/main/resources/templates/users/user-info.html
+++ b/src/main/resources/templates/users/user-info.html
@@ -26,7 +26,7 @@
     <link th:href="@{/css/users/form-validation.css}" rel="stylesheet">
 </head>
 <body class="bg-light">
-<header th:replace="/fragments/header.html :: header-config">
+<header th:replace="fragments/header :: header-config">
     헤더 삽입부
     <hr>
 </header>
@@ -80,7 +80,7 @@
         </div>
     </main>
 
-    <footer th:replace="/fragments/footer.html :: footer-config">
+    <footer th:replace="fragments/footer :: footer-config">
         <hr>
         푸터 삽입부
     </footer>


### PR DESCRIPTION
* spring 기본 templates 경로 설정(templates/) 으로 인해 th:replace 경로 맨 앞의 "/" 삭제함.
* heroku 설정 파일의 포트 설정 불필요하기 때문에 삭제함.

This fixes #29 